### PR TITLE
Allow seleting comments column in documents mode

### DIFF
--- a/client/src/lib/Advisories/Overview.svelte
+++ b/client/src/lib/Advisories/Overview.svelte
@@ -49,7 +49,8 @@
         "tracking_id",
         "initial_release_date",
         "current_release_date",
-        "version"
+        "version",
+        "comments"
       ];
 
   onMount(async () => {

--- a/client/src/lib/query/query.ts
+++ b/client/src/lib/query/query.ts
@@ -38,7 +38,8 @@ const COLUMNS = {
     "tlp",
     "cvss_v2_score",
     "cvss_v3_score",
-    "four_cves"
+    "four_cves",
+    "comments"
   ]
 };
 

--- a/pkg/database/migrations/000-setup.sql
+++ b/pkg/database/migrations/000-setup.sql
@@ -205,6 +205,8 @@ CREATE TABLE comments (
     message      varchar(10000)
 );
 
+CREATE INDEX ON comments(documents_id);
+
 -- Trigger functions to update cached comment count per advisory.
 CREATE FUNCTION incr_comments() RETURNS trigger AS $$
     DECLARE

--- a/pkg/database/migrations/005-index_comments_by_doc_id.sql
+++ b/pkg/database/migrations/005-index_comments_by_doc_id.sql
@@ -1,0 +1,9 @@
+-- This file is Free Software under the Apache-2.0 License
+-- without warranty, see README.md and LICENSES/Apache-2.0.txt for details.
+--
+-- SPDX-License-Identifier: Apache-2.0
+--
+-- SPDX-FileCopyrightText: 2024 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+-- Software-Engineering: 2024 Intevation GmbH <https://intevation.de>
+
+CREATE INDEX ON comments(documents_id);

--- a/pkg/database/queryparser.go
+++ b/pkg/database/queryparser.go
@@ -237,9 +237,9 @@ var columns = []documentColumn{
 	{"cvss_v3_score", floatType, false, false},
 	{"critical", floatType, false, false},
 	{"four_cves", stringType, false, true},
+	{"comments", intType, false, false},
 	// Advisories only
 	{"state", workflowType, true, false},
-	{"comments", intType, true, false},
 	{"recent", timeType, true, false},
 	{"versions", intType, true, false},
 }

--- a/pkg/database/sqlbuilder.go
+++ b/pkg/database/sqlbuilder.go
@@ -147,9 +147,9 @@ func (sb *SQLBuilder) accessWhere(e *Expr, b *strings.Builder) {
 		b.WriteString(versionsCount)
 	case "comments":
 		if sb.Advisory {
-			b.WriteString(commentsCount)
-		} else {
 			b.WriteString(column)
+		} else {
+			b.WriteString(commentsCount)
 		}
 	default:
 		b.WriteString(column)
@@ -381,9 +381,9 @@ func (sb *SQLBuilder) projectionsWithCasts(proj []string) string {
 			b.WriteString(versionsCount + `AS versions`)
 		case "comments":
 			if sb.Advisory {
-				b.WriteString(commentsCount + `AS comments`)
-			} else {
 				b.WriteString(p)
+			} else {
+				b.WriteString(commentsCount + `AS comments`)
 			}
 		default:
 			b.WriteString(p)

--- a/pkg/database/sqlbuilder.go
+++ b/pkg/database/sqlbuilder.go
@@ -130,9 +130,13 @@ func (sb *SQLBuilder) notWhere(e *Expr, b *strings.Builder) {
 	b.WriteByte(')')
 }
 
-const versionsCount = `(SELECT count(*) FROM documents WHERE ` +
-	`documents.publisher = advisories.publisher AND ` +
-	`documents.tracking_id = advisories.tracking_id)`
+const (
+	versionsCount = `(SELECT count(*) FROM documents WHERE ` +
+		`documents.publisher = advisories.publisher AND ` +
+		`documents.tracking_id = advisories.tracking_id)`
+	commentsCount = `(SELECT count(*) FROM comments WHERE ` +
+		`comments.documents_id = documents.id)`
+)
 
 func (sb *SQLBuilder) accessWhere(e *Expr, b *strings.Builder) {
 	switch column := e.stringValue; column {
@@ -141,6 +145,12 @@ func (sb *SQLBuilder) accessWhere(e *Expr, b *strings.Builder) {
 		b.WriteString(column)
 	case "versions":
 		b.WriteString(versionsCount)
+	case "comments":
+		if sb.Advisory {
+			b.WriteString(commentsCount)
+		} else {
+			b.WriteString(column)
+		}
 	default:
 		b.WriteString(column)
 	}
@@ -369,6 +379,12 @@ func (sb *SQLBuilder) projectionsWithCasts(proj []string) string {
 			b.WriteString("state::text")
 		case "versions":
 			b.WriteString(versionsCount + `AS versions`)
+		case "comments":
+			if sb.Advisory {
+				b.WriteString(commentsCount + `AS comments`)
+			} else {
+				b.WriteString(p)
+			}
 		default:
 			b.WriteString(p)
 		}

--- a/pkg/database/sqlbuilder.go
+++ b/pkg/database/sqlbuilder.go
@@ -30,7 +30,7 @@ func (sb *SQLBuilder) CreateWhere(e *Expr) string {
 	var b strings.Builder
 	sb.whereRecurse(e, &b)
 	sb.WhereClause = b.String()
-	return b.String()
+	return sb.WhereClause
 }
 
 func (sb *SQLBuilder) searchWhere(e *Expr, b *strings.Builder) {


### PR DESCRIPTION
Before this PR selecting the `comments` column was only allowed in `advisory` mode.
This PR allows to use in `documents` mode, too.

TODO:

- [ ] Adjust UI (Query-Editor, etc)