### PR TITLE
Add 'involved' predicate to activity by a given user

### DIFF
--- a/pkg/database/migrations/000-setup.sql
+++ b/pkg/database/migrations/000-setup.sql
@@ -274,6 +274,7 @@ CREATE TABLE events_log (
 );
 
 CREATE INDEX events_log_time_idx ON events_log(time);
+CREATE INDEX ON events_log(documents_id);
 
 -- Trigger to update cached recent value of advisory.
 CREATE FUNCTION upd_recent() RETURNS trigger AS $$

--- a/pkg/database/migrations/007-involved.sql
+++ b/pkg/database/migrations/007-involved.sql
@@ -1,0 +1,9 @@
+-- This file is Free Software under the Apache-2.0 License
+-- without warranty, see README.md and LICENSES/Apache-2.0.txt for details.
+--
+-- SPDX-License-Identifier: Apache-2.0
+--
+-- SPDX-FileCopyrightText: 2024 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+-- Software-Engineering: 2024 Intevation GmbH <https://intevation.de>
+
+CREATE INDEX ON events_log (documents_id);

--- a/pkg/database/query/parser.go
+++ b/pkg/database/query/parser.go
@@ -38,6 +38,7 @@ const (
 	search
 	csearch
 	mentioned
+	involved
 	ilike
 	ilikePID
 	now
@@ -216,6 +217,8 @@ func (et exprType) String() string {
 		return "csearch"
 	case mentioned:
 		return "mentioned"
+	case involved:
+		return "involved"
 	case ilike:
 		return "ilike"
 	case ilikePID:
@@ -705,6 +708,16 @@ func (st *stack) mentioned() {
 	})
 }
 
+func (st *stack) involved() {
+	term := st.pop()
+	term.checkValueType(stringType)
+	st.push(&Expr{
+		exprType:    involved,
+		valueType:   boolType,
+		stringValue: term.stringValue,
+	})
+}
+
 func (st *stack) ilike() {
 	needle := st.pop()
 	haystack := st.pop()
@@ -881,6 +894,8 @@ func (p *Parser) parse(input string) (*Expr, error) {
 			st.csearch(p)
 		case "mentioned":
 			st.mentioned()
+		case "involved":
+			st.involved()
 		case "as":
 			st.as(aliases)
 		case "ilike":


### PR DESCRIPTION
This PR adds an predicate `involved` to indicate activity by a given user.

E.g. `me involved` will give the advisories/documents in which the current user has done some modifications (importing, entering SSVC, commenting, etc.).