### PR TITLE
Add events endpoint to allow filtering and selection similiar to the documents endpoint

### DIFF
--- a/pkg/database/query/parser.go
+++ b/pkg/database/query/parser.go
@@ -284,8 +284,7 @@ var documentColumns = []documentColumn{
 	{"cvss_v3_score", floatType, docAdvEvtModes, false},
 	{"critical", floatType, docAdvEvtModes, false},
 	{"four_cves", stringType, docAdvEvtModes, true},
-	// Advisories and docments only
-	{"comments", intType, docAdvModes, false},
+	{"comments", intType, docAdvEvtModes, false},
 	// Advisories only
 	{"state", workflowType, advModes, false},
 	{"recent", timeType, advModes, false},

--- a/pkg/database/query/parser.go
+++ b/pkg/database/query/parser.go
@@ -59,12 +59,22 @@ const (
 	timeType
 	workflowType
 	durationType
+	eventsType
+)
+
+// ParserMode represents the operation mode of the parser.
+type ParserMode int
+
+const (
+	DocumentMode ParserMode = iota // DocumentMode operates on documents.
+	AdvisoryMode                   // AdvisoryMode operates on advisories.
+	EventMode                      // EventMode operates on events.
 )
 
 // Parser helps parsing database queries,
 type Parser struct {
-	// Advisory indicates that only advisories should be considered.
-	Advisory bool
+	// Mode indicates that only advisories should be considered.
+	Mode ParserMode
 	// Languages are the languages supported by full-text search.
 	Languages []string
 	// MinSearchLength enforces a minimal lengths of search phrases.
@@ -96,7 +106,7 @@ type Expr struct {
 type documentColumn struct {
 	name           string
 	valueType      valueType
-	advisoryOnly   bool
+	modes          []ParserMode
 	projectionOnly bool
 }
 
@@ -150,6 +160,8 @@ func (vt valueType) String() string {
 		return "workflow"
 	case durationType:
 		return "duration"
+	case eventsType:
+		return "events"
 	default:
 		return fmt.Sprintf("unknown value type %d", vt)
 	}
@@ -248,28 +260,42 @@ func (pe parseError) Error() string {
 	return string(pe)
 }
 
-// columns are the columns which can be accessed.
-var columns = []documentColumn{
-	{"id", intType, false, false},
-	{"latest", boolType, false, false},
-	{"tracking_id", stringType, false, false},
-	{"version", stringType, false, false},
-	{"publisher", stringType, false, false},
-	{"current_release_date", timeType, false, false},
-	{"initial_release_date", timeType, false, false},
-	{"rev_history_length", intType, false, false},
-	{"title", stringType, false, false},
-	{"tlp", stringType, false, false},
-	{"ssvc", stringType, false, false},
-	{"cvss_v2_score", floatType, false, false},
-	{"cvss_v3_score", floatType, false, false},
-	{"critical", floatType, false, false},
-	{"four_cves", stringType, false, true},
-	{"comments", intType, false, false},
+var (
+	docAdvEvtModes = []ParserMode{DocumentMode, AdvisoryMode, EventMode}
+	docAdvModes    = []ParserMode{DocumentMode, AdvisoryMode}
+	advModes       = []ParserMode{AdvisoryMode}
+	evtsModes      = []ParserMode{EventMode}
+)
+
+// documentColumns are the documentColumns which can be accessed.
+var documentColumns = []documentColumn{
+	{"id", intType, docAdvEvtModes, false},
+	{"latest", boolType, docAdvEvtModes, false},
+	{"tracking_id", stringType, docAdvEvtModes, false},
+	{"version", stringType, docAdvEvtModes, false},
+	{"publisher", stringType, docAdvEvtModes, false},
+	{"current_release_date", timeType, docAdvEvtModes, false},
+	{"initial_release_date", timeType, docAdvEvtModes, false},
+	{"rev_history_length", intType, docAdvEvtModes, false},
+	{"title", stringType, docAdvEvtModes, false},
+	{"tlp", stringType, docAdvEvtModes, false},
+	{"ssvc", stringType, docAdvEvtModes, false},
+	{"cvss_v2_score", floatType, docAdvEvtModes, false},
+	{"cvss_v3_score", floatType, docAdvEvtModes, false},
+	{"critical", floatType, docAdvEvtModes, false},
+	{"four_cves", stringType, docAdvEvtModes, true},
+	// Advisories and docments only
+	{"comments", intType, docAdvModes, false},
 	// Advisories only
-	{"state", workflowType, true, false},
-	{"recent", timeType, true, false},
-	{"versions", intType, true, false},
+	{"state", workflowType, advModes, false},
+	{"recent", timeType, advModes, false},
+	{"versions", intType, advModes, false},
+	// Events only
+	{"event", eventsType, evtsModes, false},
+	{"event_state", workflowType, evtsModes, false},
+	{"time", timeType, evtsModes, false},
+	{"actor", stringType, evtsModes, false},
+	{"comments_id", intType, evtsModes, false},
 }
 
 // supportedLangs are the default languages.
@@ -279,15 +305,60 @@ var supportedLangs = []string{
 	"german",
 }
 
+var (
+	// baseActions are the action available in every parser.
+	baseActions = map[string]func(*Parser, *stack){
+		"true":      (*Parser).pushTrue,
+		"false":     (*Parser).pushFalse,
+		"not":       (*Parser).pushNot,
+		"and":       curry3((*Parser).pushBinary, and),
+		"or":        curry3((*Parser).pushBinary, or),
+		"float":     (*Parser).pushFloat,
+		"integer":   (*Parser).pushInteger,
+		"timestamp": (*Parser).pushTimestamp,
+		"workflow":  (*Parser).pushWorkflow,
+		"events":    (*Parser).pushEvents,
+		"=":         curry3((*Parser).pushCmp, eq),
+		"!=":        curry3((*Parser).pushCmp, ne),
+		"<":         curry3((*Parser).pushCmp, lt),
+		"<=":        curry3((*Parser).pushCmp, le),
+		">":         curry3((*Parser).pushCmp, gt),
+		">=":        curry3((*Parser).pushCmp, ge),
+		"ilike":     (*Parser).pushILike,
+		"ilikepid":  (*Parser).pushILikePID,
+		"now":       (*Parser).pushNow,
+		"duration":  (*Parser).pushDuration,
+		"+":         curry3((*Parser).pushBinary, add),
+		"-":         curry3((*Parser).pushBinary, sub),
+		"/":         curry3((*Parser).pushBinary, div),
+		"*":         curry3((*Parser).pushBinary, mul),
+		"me":        (*Parser).pushMe,
+	}
+	// advancedActions are action only available is documents and advisories.
+	advancedActions = map[string]func(*Parser, *stack){
+		"search":    (*Parser).pushSearch,
+		"csearch":   (*Parser).pushCSearch,
+		"mentioned": (*Parser).pushMentioned,
+		"involved":  (*Parser).pushInvolved,
+		"as":        (*Parser).pushAs,
+	}
+	// actions is for fast looking up actions along the parser mode.
+	actions = map[ParserMode]map[string]func(*Parser, *stack){
+		DocumentMode: buildActions(DocumentMode),
+		AdvisoryMode: buildActions(AdvisoryMode),
+		EventMode:    buildActions(EventMode),
+	}
+)
+
 // ExistsDocumentColumn returns true if a column in document exists.
-func ExistsDocumentColumn(name string, advisory bool) bool {
-	return findDocumentColumn(name, advisory) != nil
+func ExistsDocumentColumn(name string, mode ParserMode) bool {
+	return findDocumentColumn(name, mode) != nil
 }
 
-func findDocumentColumn(name string, advisory bool) *documentColumn {
-	for i := range columns {
-		if col := &columns[i]; col.name == name {
-			if col.advisoryOnly && !advisory {
+func findDocumentColumn(name string, mode ParserMode) *documentColumn {
+	for i := range documentColumns {
+		if col := &documentColumns[i]; col.name == name {
+			if !slices.Contains(col.modes, mode) {
 				return nil
 			}
 			return col
@@ -576,7 +647,7 @@ func parseTime(s string) time.Time {
 	panic(parseError(fmt.Sprintf("cannot parse %q as time", s)))
 }
 
-func (*Parser) pushTime(st *stack) {
+func (*Parser) pushTimestamp(st *stack) {
 	if st.top().valueType == timeType {
 		return
 	}
@@ -631,6 +702,20 @@ func parseWorkflow(s string) string {
 	return s
 }
 
+var validEvents = []string{
+	"import_document", "delete_document",
+	"state_change",
+	"add_sscv", "change_sscv", "delete_sscv",
+	"add_comment", "change_comment", "delete_comment",
+}
+
+func parseEvents(s string) string {
+	if !slices.Contains(validEvents, s) {
+		panic(parseError(fmt.Sprintf("%q is not a valid event", s)))
+	}
+	return s
+}
+
 func (*Parser) pushWorkflow(st *stack) {
 	if st.top().valueType == workflowType {
 		return
@@ -651,6 +736,34 @@ func (*Parser) pushWorkflow(st *stack) {
 			st.push(&Expr{
 				exprType:  cast,
 				valueType: workflowType,
+				children:  []*Expr{e},
+			})
+		default:
+			panic(parseError("unsupported cast"))
+		}
+	}
+}
+
+func (*Parser) pushEvents(st *stack) {
+	if st.top().valueType == eventsType {
+		return
+	}
+	switch e := st.pop(); e.exprType {
+	case cnst:
+		switch e.valueType {
+		case stringType:
+			st.push(&Expr{
+				exprType:    cnst,
+				valueType:   eventsType,
+				stringValue: parseEvents(e.stringValue),
+			})
+		}
+	default:
+		switch e.valueType {
+		case stringType:
+			st.push(&Expr{
+				exprType:  cast,
+				valueType: eventsType,
 				children:  []*Expr{e},
 			})
 		default:
@@ -865,60 +978,18 @@ func split(input string, fn func(string, bool)) {
 	}
 }
 
-var (
-	baseActions = map[string]func(*Parser, *stack){
-		"true":      (*Parser).pushTrue,
-		"false":     (*Parser).pushFalse,
-		"not":       (*Parser).pushNot,
-		"and":       curry3((*Parser).pushBinary, and),
-		"or":        curry3((*Parser).pushBinary, or),
-		"float":     (*Parser).pushFloat,
-		"integer":   (*Parser).pushInteger,
-		"time":      (*Parser).pushTime,
-		"workflow":  (*Parser).pushWorkflow,
-		"=":         curry3((*Parser).pushCmp, eq),
-		"!=":        curry3((*Parser).pushCmp, ne),
-		"<":         curry3((*Parser).pushCmp, lt),
-		"<=":        curry3((*Parser).pushCmp, le),
-		">":         curry3((*Parser).pushCmp, gt),
-		">=":        curry3((*Parser).pushCmp, ge),
-		"search":    (*Parser).pushSearch,
-		"csearch":   (*Parser).pushCSearch,
-		"mentioned": (*Parser).pushMentioned,
-		"involved":  (*Parser).pushInvolved,
-		"as":        (*Parser).pushAs,
-		"ilike":     (*Parser).pushILike,
-		"ilikepid":  (*Parser).pushILikePID,
-		"now":       (*Parser).pushNow,
-		"duration":  (*Parser).pushDuration,
-		"+":         curry3((*Parser).pushBinary, add),
-		"-":         curry3((*Parser).pushBinary, sub),
-		"/":         curry3((*Parser).pushBinary, div),
-		"*":         curry3((*Parser).pushBinary, mul),
-		"me":        (*Parser).pushMe,
-	}
-	documentActions = buildActions(false)
-	advisoryActions = buildActions(true)
-)
-
-func buildActions(advisory bool) map[string]func(*Parser, *stack) {
+func buildActions(mode ParserMode) map[string]func(*Parser, *stack) {
 	actions := maps.Clone(baseActions)
-	for i := range columns {
-		column := &columns[i]
-		if column.projectionOnly {
-			continue
+	for i := range documentColumns {
+		col := &documentColumns[i]
+		if !col.projectionOnly && slices.Contains(col.modes, mode) {
+			actions["$"+col.name] = func(p *Parser, st *stack) { p.pushAccess(st, col) }
 		}
-		var fn func(*Parser, *stack)
-		if !advisory && column.advisoryOnly {
-			fn = func(*Parser, *stack) {
-				panic(parseError(
-					fmt.Sprintf("column %q only accessible in advisory mode",
-						column.name)))
-			}
-		} else {
-			fn = func(p *Parser, st *stack) { p.pushAccess(st, column) }
-		}
-		actions["$"+column.name] = fn
+	}
+	// Fill in extra actions
+	switch mode {
+	case DocumentMode, AdvisoryMode:
+		maps.Copy(actions, advancedActions)
 	}
 	return actions
 }
@@ -929,18 +1000,15 @@ func curry3[A, B, C any](fn func(A, B, C), c C) func(A, B) {
 
 func (p *Parser) parse(input string) (*Expr, error) {
 
-	actions := documentActions
-	if p.Advisory {
-		actions = advisoryActions
-	}
-
 	p.aliases = nil
+
 	st := stack{}
+	acts := actions[p.Mode]
 
 	split(input, func(field string, isString bool) {
 		if !isString {
-			if action := actions[field]; action != nil {
-				action(p, &st)
+			if act := acts[field]; act != nil {
+				act(p, &st)
 				return
 			}
 		}
@@ -949,7 +1017,7 @@ func (p *Parser) parse(input string) (*Expr, error) {
 
 	if len(st) != 1 {
 		return nil, parseError(fmt.Sprintf(
-			"invalid number of expression roots: expected 1 have %d: %+v", len(st), st))
+			"invalid number of expression roots: expected 1 have %d", len(st)))
 	}
 	e := st.top()
 	e.checkValueType(boolType)

--- a/pkg/database/query/parser.go
+++ b/pkg/database/query/parser.go
@@ -333,14 +333,14 @@ var (
 		"/":         curry3((*Parser).pushBinary, div),
 		"*":         curry3((*Parser).pushBinary, mul),
 		"me":        (*Parser).pushMe,
+		"mentioned": (*Parser).pushMentioned,
+		"involved":  (*Parser).pushInvolved,
 	}
 	// advancedActions are action only available is documents and advisories.
 	advancedActions = map[string]func(*Parser, *stack){
-		"search":    (*Parser).pushSearch,
-		"csearch":   (*Parser).pushCSearch,
-		"mentioned": (*Parser).pushMentioned,
-		"involved":  (*Parser).pushInvolved,
-		"as":        (*Parser).pushAs,
+		"search":  (*Parser).pushSearch,
+		"csearch": (*Parser).pushCSearch,
+		"as":      (*Parser).pushAs,
 	}
 	// actions is for fast looking up actions along the parser mode.
 	actions = map[ParserMode]map[string]func(*Parser, *stack){

--- a/pkg/database/query/sqlbuilder.go
+++ b/pkg/database/query/sqlbuilder.go
@@ -89,12 +89,16 @@ func (sb *SQLBuilder) mentionedWhere(e *Expr, b *strings.Builder) {
 		fmt.Fprintf(b, "EXISTS(SELECT 1 FROM comments WHERE ts @@ "+tsquery+"($%d) "+
 			"AND comments.documents_id = documents.id)",
 			sb.replacementIndex(e.stringValue)+1)
+	case EventMode:
+		fmt.Fprintf(b, "EXISTS(SELECT 1 FROM comments WHERE ts @@ "+tsquery+"($%d) "+
+			"AND comments.id = events_log.comments_id)",
+			sb.replacementIndex(e.stringValue)+1)
 	}
 }
 
 func (sb *SQLBuilder) involvedWhere(e *Expr, b *strings.Builder) {
 	switch sb.Mode {
-	case AdvisoryMode:
+	case AdvisoryMode, EventMode:
 		fmt.Fprintf(b, "EXISTS(SELECT 1 FROM events_log JOIN documents docs "+
 			"ON events_log.documents_id = docs.id "+
 			"WHERE actor = $%d "+
@@ -102,7 +106,7 @@ func (sb *SQLBuilder) involvedWhere(e *Expr, b *strings.Builder) {
 			sb.replacementIndex(e.stringValue)+1)
 	case DocumentMode:
 		fmt.Fprintf(b, "EXISTS(SELECT 1 FROM events_log WHERE actor = $%d "+
-			"AND comments.documents_id = documents.id)",
+			"AND events_log.documents_id = documents.id)",
 			sb.replacementIndex(e.stringValue)+1)
 	}
 }

--- a/pkg/database/query/sqlbuilder.go
+++ b/pkg/database/query/sqlbuilder.go
@@ -189,8 +189,10 @@ const (
 	versionsCount = `(SELECT count(*) FROM documents WHERE ` +
 		`documents.publisher = advisories.publisher AND ` +
 		`documents.tracking_id = advisories.tracking_id)`
-	commentsCount = `(SELECT count(*) FROM comments WHERE ` +
+	commentsCountDocuments = `(SELECT count(*) FROM comments WHERE ` +
 		`comments.documents_id = documents.id)`
+	commentsCountEvents = `(SELECT count(*) FROM comments WHERE ` +
+		`comments.documents_id = documents_id)`
 )
 
 func (sb *SQLBuilder) accessWhere(e *Expr, b *strings.Builder) {
@@ -205,7 +207,9 @@ func (sb *SQLBuilder) accessWhere(e *Expr, b *strings.Builder) {
 		case AdvisoryMode:
 			b.WriteString(column)
 		case DocumentMode:
-			b.WriteString(commentsCount)
+			b.WriteString(commentsCountDocuments)
+		case EventMode:
+			b.WriteString(commentsCountEvents)
 		}
 	default:
 		b.WriteString(column)
@@ -459,7 +463,9 @@ func (sb *SQLBuilder) projectionsWithCasts(b *strings.Builder, proj []string) {
 			case AdvisoryMode:
 				b.WriteString(p)
 			case DocumentMode:
-				b.WriteString(commentsCount + `AS comments`)
+				b.WriteString(commentsCountDocuments + `AS comments`)
+			case EventMode:
+				b.WriteString(commentsCountEvents + `AS comments`)
 			}
 		default:
 			b.WriteString(p)

--- a/pkg/web/controller.go
+++ b/pkg/web/controller.go
@@ -98,6 +98,7 @@ func (c *Controller) Bind() http.Handler {
 	api.DELETE("/queries/:query", authAll, c.deleteStoredQuery)
 
 	// Events
+	api.GET("/events", authEdReAu, c.overviewEvents)
 	api.GET("/events/:document", authEdReAu, c.viewEvents)
 
 	// State change

--- a/pkg/web/documents.go
+++ b/pkg/web/documents.go
@@ -206,8 +206,13 @@ func (c *Controller) overviewDocuments(ctx *gin.Context) {
 		return
 	}
 
+	mode := query.DocumentMode
+	if advisory {
+		mode = query.AdvisoryMode
+	}
+
 	parser := query.Parser{
-		Advisory:        advisory,
+		Mode:            mode,
 		Languages:       c.cfg.Database.TextSearch,
 		MinSearchLength: MinSearchLength,
 		Me:              ctx.GetString("uid"),
@@ -231,7 +236,7 @@ func (c *Controller) overviewDocuments(ctx *gin.Context) {
 		expr = expr.And(query.BoolField("latest"))
 	}
 
-	builder := query.SQLBuilder{Advisory: advisory}
+	builder := query.SQLBuilder{Mode: mode}
 	builder.CreateWhere(expr)
 
 	fields := strings.Fields(

--- a/pkg/web/events.go
+++ b/pkg/web/events.go
@@ -11,9 +11,11 @@ package web
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -23,6 +25,123 @@ import (
 	"github.com/ISDuBA/ISDuBA/pkg/database/query"
 	"github.com/ISDuBA/ISDuBA/pkg/models"
 )
+
+func (c *Controller) overviewEvents(ctx *gin.Context) {
+
+	parser := query.Parser{
+		Mode:            query.EventMode,
+		Languages:       c.cfg.Database.TextSearch,
+		MinSearchLength: MinSearchLength,
+		Me:              ctx.GetString("uid"),
+	}
+
+	// The query to filter the documents.
+	expr, err := parser.Parse(ctx.DefaultQuery("query", "true"))
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	// Filter the allowed
+	if tlps := c.tlps(ctx); len(tlps) > 0 {
+		tlpExpr := tlps.AsExpr()
+		expr = expr.And(tlpExpr)
+	}
+
+	builder := query.SQLBuilder{Mode: query.EventMode}
+	builder.CreateWhere(expr)
+
+	fields := strings.Fields(
+		ctx.DefaultQuery("columns", "event event_state time actor comments_id id"))
+
+	if err := builder.CheckProjections(fields); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	orderFields := strings.Fields(ctx.DefaultQuery("order", "-time"))
+	order, err := builder.CreateOrder(orderFields)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	var (
+		calcCount     bool
+		count         int64
+		limit, offset int64 = -1, -1
+	)
+
+	if count := ctx.Query("count"); count != "" {
+		calcCount = true
+	}
+
+	if lim := ctx.Query("limit"); lim != "" {
+		limit, err = strconv.ParseInt(lim, 10, 64)
+		if err != nil {
+			ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+	}
+
+	if ofs := ctx.Query("offset"); ofs != "" {
+		offset, err = strconv.ParseInt(ofs, 10, 64)
+		if err != nil {
+			ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+	}
+
+	var results []map[string]any
+
+	if err := c.db.Run(
+		ctx.Request.Context(),
+		func(rctx context.Context, conn *pgxpool.Conn) error {
+			if calcCount {
+				if err := conn.QueryRow(
+					rctx,
+					builder.CreateCountSQL(),
+					builder.Replacements...,
+				).Scan(&count); err != nil {
+					return fmt.Errorf("cannot calculate count %w", err)
+				}
+			}
+			// Skip fields if they are not requested.
+			if len(fields) == 0 {
+				return nil
+			}
+
+			sql := builder.CreateQuery(fields, order, limit, offset)
+
+			if slog.Default().Enabled(rctx, slog.LevelDebug) {
+				slog.Debug("events", "SQL", qndSQLReplace(sql, builder.Replacements))
+			}
+			rows, err := conn.Query(rctx, sql, builder.Replacements...)
+			if err != nil {
+				return fmt.Errorf("cannot fetch results: %w", err)
+			}
+			defer rows.Close()
+			if results, err = scanRows(rows, fields); err != nil {
+				return fmt.Errorf("loading data failed: %w", err)
+			}
+			return nil
+		},
+		c.cfg.Database.MaxQueryDuration, // In case the user provided a very expensive query.
+	); err != nil {
+		slog.Error("database error", "err", err)
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	h := gin.H{}
+	if calcCount {
+		h["count"] = count
+	}
+	if len(results) > 0 {
+		h["events"] = results
+	}
+	ctx.JSON(http.StatusOK, h)
+}
 
 func (c *Controller) viewEvents(ctx *gin.Context) {
 	idS := ctx.Param("document")

--- a/pkg/web/queries.go
+++ b/pkg/web/queries.go
@@ -70,8 +70,12 @@ func (c *Controller) createStoredQuery(ctx *gin.Context) {
 		return
 	}
 
+	mode := query.DocumentMode
+	if sq.Advisories {
+		mode = query.AdvisoryMode
+	}
 	parser := query.Parser{
-		Advisory:  sq.Advisories,
+		Mode:      mode,
 		Languages: c.cfg.Database.TextSearch,
 	}
 
@@ -97,7 +101,7 @@ func (c *Controller) createStoredQuery(ctx *gin.Context) {
 		return
 	}
 
-	builder := query.SQLBuilder{Advisory: sq.Advisories}
+	builder := query.SQLBuilder{Mode: mode}
 	builder.CreateWhere(expr)
 	if err := builder.CheckProjections(sq.Columns); err != nil {
 		ctx.JSON(http.StatusBadRequest, gin.H{
@@ -406,8 +410,12 @@ func (c *Controller) updateStoredQuery(ctx *gin.Context) {
 				sq.Advisories = advisories
 			}
 
+			mode := query.DocumentMode
+			if sq.Advisories {
+				mode = query.AdvisoryMode
+			}
 			parser := query.Parser{
-				Advisory:  sq.Advisories,
+				Mode:      mode,
 				Languages: c.cfg.Database.TextSearch,
 			}
 
@@ -428,7 +436,7 @@ func (c *Controller) updateStoredQuery(ctx *gin.Context) {
 				expr = expr.And(query.BoolField("latest"))
 			}
 
-			builder := query.SQLBuilder{Advisory: sq.Advisories}
+			builder := query.SQLBuilder{Mode: mode}
 			builder.CreateWhere(expr)
 
 			// Check columns


### PR DESCRIPTION
This PR implements  filtering and selecting on events like the /api/documents endpoint does.

Supports `query`, `order`, `limit`, `offset` and `count`.

Example:

Returns events which are not an import and are done in the last hour.

```
curl -s -D /dev/stderr \
   -H "Authorization: Bearer $TOKEN" \
   --get \
   --data-urlencode 'limit=10' \
   --data-urlencode 'count=true' \
  --data-urlencode 'query=$event import_document events != now 1h duration - $time <=' \
   http://localhost:8081/api/events | jq .
```