### PR TITLE
Simplify parameter parsing in endpoints a bit.

### DIFF
--- a/pkg/web/comments.go
+++ b/pkg/web/comments.go
@@ -13,7 +13,6 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
-	"strconv"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -25,10 +24,8 @@ import (
 )
 
 func (c *Controller) createComment(ctx *gin.Context) {
-	docIDs := ctx.Param("document")
-	docID, err := strconv.ParseInt(docIDs, 10, 64)
-	if err != nil {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	docID, ok := parseInt(ctx, ctx.Param("document"))
+	if !ok {
 		return
 	}
 
@@ -158,10 +155,8 @@ func (c *Controller) createComment(ctx *gin.Context) {
 }
 
 func (c *Controller) updateComment(ctx *gin.Context) {
-	commentIDs := ctx.Param("id")
-	commentID, err := strconv.ParseInt(commentIDs, 10, 64)
-	if err != nil {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	commentID, ok := parseInt(ctx, ctx.Param("id"))
+	if !ok {
 		return
 	}
 	var (
@@ -232,10 +227,8 @@ type comment struct {
 }
 
 func (c *Controller) viewComment(ctx *gin.Context) {
-	idS := ctx.Param("id")
-	id, err := strconv.ParseInt(idS, 10, 64)
-	if err != nil {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	id, ok := parseInt(ctx, ctx.Param("id"))
+	if !ok {
 		return
 	}
 
@@ -268,10 +261,8 @@ func (c *Controller) viewComment(ctx *gin.Context) {
 }
 
 func (c *Controller) viewComments(ctx *gin.Context) {
-	idS := ctx.Param("document")
-	id, err := strconv.ParseInt(idS, 10, 64)
-	if err != nil {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	id, ok := parseInt(ctx, ctx.Param("document"))
+	if !ok {
 		return
 	}
 

--- a/pkg/web/comments.go
+++ b/pkg/web/comments.go
@@ -24,7 +24,7 @@ import (
 )
 
 func (c *Controller) createComment(ctx *gin.Context) {
-	docID, ok := parseInt(ctx, ctx.Param("document"))
+	docID, ok := parse(ctx, toInt64, ctx.Param("document"))
 	if !ok {
 		return
 	}
@@ -155,7 +155,7 @@ func (c *Controller) createComment(ctx *gin.Context) {
 }
 
 func (c *Controller) updateComment(ctx *gin.Context) {
-	commentID, ok := parseInt(ctx, ctx.Param("id"))
+	commentID, ok := parse(ctx, toInt64, ctx.Param("id"))
 	if !ok {
 		return
 	}
@@ -227,7 +227,7 @@ type comment struct {
 }
 
 func (c *Controller) viewComment(ctx *gin.Context) {
-	id, ok := parseInt(ctx, ctx.Param("id"))
+	id, ok := parse(ctx, toInt64, ctx.Param("id"))
 	if !ok {
 		return
 	}
@@ -261,7 +261,7 @@ func (c *Controller) viewComment(ctx *gin.Context) {
 }
 
 func (c *Controller) viewComments(ctx *gin.Context) {
-	id, ok := parseInt(ctx, ctx.Param("document"))
+	id, ok := parse(ctx, toInt64, ctx.Param("document"))
 	if !ok {
 		return
 	}

--- a/pkg/web/documents.go
+++ b/pkg/web/documents.go
@@ -34,7 +34,7 @@ const MinSearchLength = 2 // Makes at least "Go" searchable ;-)
 // deleteDocument is an end point for deleting a document.
 func (c *Controller) deleteDocument(ctx *gin.Context) {
 	// Get an ID from context
-	docID, ok := parseInt(ctx, ctx.Param("id"))
+	docID, ok := parse(ctx, toInt64, ctx.Param("id"))
 	if !ok {
 		return
 	}
@@ -140,7 +140,7 @@ func (c *Controller) importDocument(ctx *gin.Context) {
 
 // viewDocument is an end point to export a document.
 func (c *Controller) viewDocument(ctx *gin.Context) {
-	id, ok := parseInt(ctx, ctx.Param("id"))
+	id, ok := parse(ctx, toInt64, ctx.Param("id"))
 	if !ok {
 		return
 	}
@@ -183,7 +183,7 @@ func (c *Controller) viewDocument(ctx *gin.Context) {
 func (c *Controller) overviewDocuments(ctx *gin.Context) {
 
 	// Use the advisories.
-	advisory, ok := parseBool(ctx, ctx.DefaultQuery("advisories", "false"))
+	advisory, ok := parse(ctx, toBool, ctx.DefaultQuery("advisories", "false"))
 	if !ok {
 		return
 	}
@@ -242,13 +242,13 @@ func (c *Controller) overviewDocuments(ctx *gin.Context) {
 	calcCount = ctx.Query("count") != ""
 
 	if lim := ctx.Query("limit"); lim != "" {
-		if limit, ok = parseInt(ctx, lim); !ok {
+		if limit, ok = parse(ctx, toInt64, lim); !ok {
 			return
 		}
 	}
 
 	if ofs := ctx.Query("offset"); ofs != "" {
-		if offset, ok = parseInt(ctx, ofs); !ok {
+		if offset, ok = parse(ctx, toInt64, ofs); !ok {
 			return
 		}
 	}

--- a/pkg/web/documents.go
+++ b/pkg/web/documents.go
@@ -200,9 +200,8 @@ func (c *Controller) overviewDocuments(ctx *gin.Context) {
 	}
 
 	// The query to filter the documents.
-	expr, err := parser.Parse(ctx.DefaultQuery("query", "true"))
-	if err != nil {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	expr, ok := parse(ctx, parser.Parse, ctx.DefaultQuery("query", "true"))
+	if !ok {
 		return
 	}
 

--- a/pkg/web/events.go
+++ b/pkg/web/events.go
@@ -34,9 +34,8 @@ func (c *Controller) overviewEvents(ctx *gin.Context) {
 	}
 
 	// The query to filter the documents.
-	expr, err := parser.Parse(ctx.DefaultQuery("query", "true"))
-	if err != nil {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	expr, ok := parse(ctx, parser.Parse, ctx.DefaultQuery("query", "true"))
+	if !ok {
 		return
 	}
 
@@ -62,7 +61,7 @@ func (c *Controller) overviewEvents(ctx *gin.Context) {
 	}
 
 	var (
-		calcCount, ok bool
+		calcCount     bool
 		count         int64
 		limit, offset int64 = -1, -1
 	)

--- a/pkg/web/events.go
+++ b/pkg/web/events.go
@@ -70,13 +70,13 @@ func (c *Controller) overviewEvents(ctx *gin.Context) {
 	calcCount = ctx.Query("count") != ""
 
 	if lim := ctx.Query("limit"); lim != "" {
-		if limit, ok = parseInt(ctx, lim); !ok {
+		if limit, ok = parse(ctx, toInt64, lim); !ok {
 			return
 		}
 	}
 
 	if ofs := ctx.Query("offset"); ofs != "" {
-		if offset, ok = parseInt(ctx, ofs); !ok {
+		if offset, ok = parse(ctx, toInt64, ofs); !ok {
 			return
 		}
 	}
@@ -133,7 +133,7 @@ func (c *Controller) overviewEvents(ctx *gin.Context) {
 }
 
 func (c *Controller) viewEvents(ctx *gin.Context) {
-	id, ok := parseInt(ctx, ctx.Param("document"))
+	id, ok := parse(ctx, toInt64, ctx.Param("document"))
 	if !ok {
 		return
 	}

--- a/pkg/web/events.go
+++ b/pkg/web/events.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"strconv"
 	"strings"
 	"time"
 
@@ -63,27 +62,21 @@ func (c *Controller) overviewEvents(ctx *gin.Context) {
 	}
 
 	var (
-		calcCount     bool
+		calcCount, ok bool
 		count         int64
 		limit, offset int64 = -1, -1
 	)
 
-	if count := ctx.Query("count"); count != "" {
-		calcCount = true
-	}
+	calcCount = ctx.Query("count") != ""
 
 	if lim := ctx.Query("limit"); lim != "" {
-		limit, err = strconv.ParseInt(lim, 10, 64)
-		if err != nil {
-			ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		if limit, ok = parseInt(ctx, lim); !ok {
 			return
 		}
 	}
 
 	if ofs := ctx.Query("offset"); ofs != "" {
-		offset, err = strconv.ParseInt(ofs, 10, 64)
-		if err != nil {
-			ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		if offset, ok = parseInt(ctx, ofs); !ok {
 			return
 		}
 	}
@@ -140,10 +133,8 @@ func (c *Controller) overviewEvents(ctx *gin.Context) {
 }
 
 func (c *Controller) viewEvents(ctx *gin.Context) {
-	idS := ctx.Param("document")
-	id, err := strconv.ParseInt(idS, 10, 64)
-	if err != nil {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	id, ok := parseInt(ctx, ctx.Param("document"))
+	if !ok {
 		return
 	}
 

--- a/pkg/web/queries.go
+++ b/pkg/web/queries.go
@@ -43,14 +43,14 @@ func (c *Controller) createStoredQuery(ctx *gin.Context) {
 
 	// Advisories flag
 	if advisories, ok := ctx.GetPostForm("advisories"); ok {
-		if sq.Advisories, ok = parseBool(ctx, advisories); !ok {
+		if sq.Advisories, ok = parse(ctx, toBool, advisories); !ok {
 			return
 		}
 	}
 
 	// Global flag
 	if global, ok := ctx.GetPostForm("global"); ok {
-		if sq.Global, ok = parseBool(ctx, global); !ok {
+		if sq.Global, ok = parse(ctx, toBool, global); !ok {
 			return
 		}
 	}
@@ -217,7 +217,7 @@ func (c *Controller) listStoredQueries(ctx *gin.Context) {
 
 func (c *Controller) deleteStoredQuery(ctx *gin.Context) {
 
-	queryID, ok := parseInt(ctx, ctx.Param("query"))
+	queryID, ok := parse(ctx, toInt64, ctx.Param("query"))
 	if !ok {
 		return
 	}
@@ -260,7 +260,7 @@ func (c *Controller) deleteStoredQuery(ctx *gin.Context) {
 
 func (c *Controller) fetchStoredQuery(ctx *gin.Context) {
 
-	queryID, ok := parseInt(ctx, ctx.Param("query"))
+	queryID, ok := parse(ctx, toInt64, ctx.Param("query"))
 	if !ok {
 		return
 	}
@@ -312,7 +312,7 @@ func (c *Controller) fetchStoredQuery(ctx *gin.Context) {
 
 func (c *Controller) updateStoredQuery(ctx *gin.Context) {
 
-	queryID, ok := parseInt(ctx, ctx.Param("query"))
+	queryID, ok := parse(ctx, toInt64, ctx.Param("query"))
 	if !ok {
 		return
 	}

--- a/pkg/web/queries.go
+++ b/pkg/web/queries.go
@@ -43,22 +43,14 @@ func (c *Controller) createStoredQuery(ctx *gin.Context) {
 
 	// Advisories flag
 	if advisories, ok := ctx.GetPostForm("advisories"); ok {
-		var err error
-		if sq.Advisories, err = strconv.ParseBool(advisories); err != nil {
-			ctx.JSON(http.StatusBadRequest, gin.H{
-				"error": "bad 'advisories' value: " + err.Error(),
-			})
+		if sq.Advisories, ok = parseBool(ctx, advisories); !ok {
 			return
 		}
 	}
 
 	// Global flag
 	if global, ok := ctx.GetPostForm("global"); ok {
-		var err error
-		if sq.Global, err = strconv.ParseBool(global); err != nil {
-			ctx.JSON(http.StatusBadRequest, gin.H{
-				"error": "bad 'global' value: " + err.Error(),
-			})
+		if sq.Global, ok = parseBool(ctx, global); !ok {
 			return
 		}
 	}
@@ -225,9 +217,8 @@ func (c *Controller) listStoredQueries(ctx *gin.Context) {
 
 func (c *Controller) deleteStoredQuery(ctx *gin.Context) {
 
-	queryID, err := strconv.ParseInt(ctx.Param("query"), 10, 64)
-	if err != nil {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	queryID, ok := parseInt(ctx, ctx.Param("query"))
+	if !ok {
 		return
 	}
 
@@ -269,9 +260,8 @@ func (c *Controller) deleteStoredQuery(ctx *gin.Context) {
 
 func (c *Controller) fetchStoredQuery(ctx *gin.Context) {
 
-	queryID, err := strconv.ParseInt(ctx.Param("query"), 10, 64)
-	if err != nil {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	queryID, ok := parseInt(ctx, ctx.Param("query"))
+	if !ok {
 		return
 	}
 
@@ -322,9 +312,8 @@ func (c *Controller) fetchStoredQuery(ctx *gin.Context) {
 
 func (c *Controller) updateStoredQuery(ctx *gin.Context) {
 
-	queryID, err := strconv.ParseInt(ctx.Param("query"), 10, 64)
-	if err != nil {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	queryID, ok := parseInt(ctx, ctx.Param("query"))
+	if !ok {
 		return
 	}
 

--- a/pkg/web/queries.go
+++ b/pkg/web/queries.go
@@ -70,11 +70,8 @@ func (c *Controller) createStoredQuery(ctx *gin.Context) {
 
 	// The query to filter the documents.
 	sq.Query = ctx.DefaultPostForm("query", "true")
-	expr, err := parser.Parse(sq.Query)
-	if err != nil {
-		ctx.JSON(http.StatusBadRequest, gin.H{
-			"error": "bad 'query' value: " + err.Error(),
-		})
+	expr, ok := parse(ctx, parser.Parse, sq.Query)
+	if !ok {
 		return
 	}
 	// In advisory mode we only show the latest.

--- a/pkg/web/ssvc.go
+++ b/pkg/web/ssvc.go
@@ -14,7 +14,6 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
-	"strconv"
 
 	"github.com/gin-gonic/gin"
 	"github.com/jackc/pgx/v5"
@@ -25,9 +24,8 @@ import (
 
 func (c *Controller) changeSSVC(ctx *gin.Context) {
 
-	documentID, err := strconv.ParseInt(ctx.Param("document"), 10, 64)
-	if err != nil {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	documentID, ok := parseInt(ctx, ctx.Param("document"))
+	if !ok {
 		return
 	}
 

--- a/pkg/web/ssvc.go
+++ b/pkg/web/ssvc.go
@@ -24,7 +24,7 @@ import (
 
 func (c *Controller) changeSSVC(ctx *gin.Context) {
 
-	documentID, ok := parseInt(ctx, ctx.Param("document"))
+	documentID, ok := parse(ctx, toInt64, ctx.Param("document"))
 	if !ok {
 		return
 	}

--- a/pkg/web/tempdocuments.go
+++ b/pkg/web/tempdocuments.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strconv"
 	"strings"
 
 	"github.com/csaf-poc/csaf_distribution/v3/csaf"
@@ -73,10 +72,8 @@ func (c *Controller) overviewTempDocuments(ctx *gin.Context) {
 }
 
 func (c *Controller) viewTempDocument(ctx *gin.Context) {
-	idS := ctx.Param("id")
-	id, err := strconv.ParseInt(idS, 10, 64)
-	if err != nil {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	id, ok := parseInt(ctx, ctx.Param("id"))
+	if !ok {
 		return
 	}
 	user := ctx.GetString("uid")
@@ -97,10 +94,8 @@ func (c *Controller) viewTempDocument(ctx *gin.Context) {
 }
 
 func (c *Controller) deleteTempDocument(ctx *gin.Context) {
-	idS := ctx.Param("id")
-	id, err := strconv.ParseInt(idS, 10, 64)
-	if err != nil {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	id, ok := parseInt(ctx, ctx.Param("id"))
+	if !ok {
 		return
 	}
 	user := ctx.GetString("uid")

--- a/pkg/web/tempdocuments.go
+++ b/pkg/web/tempdocuments.go
@@ -72,7 +72,7 @@ func (c *Controller) overviewTempDocuments(ctx *gin.Context) {
 }
 
 func (c *Controller) viewTempDocument(ctx *gin.Context) {
-	id, ok := parseInt(ctx, ctx.Param("id"))
+	id, ok := parse(ctx, toInt64, ctx.Param("id"))
 	if !ok {
 		return
 	}
@@ -94,7 +94,7 @@ func (c *Controller) viewTempDocument(ctx *gin.Context) {
 }
 
 func (c *Controller) deleteTempDocument(ctx *gin.Context) {
-	id, ok := parseInt(ctx, ctx.Param("id"))
+	id, ok := parse(ctx, toInt64, ctx.Param("id"))
 	if !ok {
 		return
 	}

--- a/pkg/web/util.go
+++ b/pkg/web/util.go
@@ -1,0 +1,38 @@
+// This file is Free Software under the Apache-2.0 License
+// without warranty, see README.md and LICENSES/Apache-2.0.txt for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: 2024 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+// Software-Engineering: 2024 Intevation GmbH <https://intevation.de>
+
+package web
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+)
+
+// parseInt parses a given string to a 64bit integer.
+// If that fails a bad request status code is set in the gin context.
+func parseInt(ctx *gin.Context, s string) (int64, bool) {
+	v, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return 0, false
+	}
+	return v, true
+}
+
+// parseBool parses a given string to a bool.
+// If that fails a bad request status code is set in the gin context.
+func parseBool(ctx *gin.Context, s string) (bool, bool) {
+	v, err := strconv.ParseBool(s)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return false, false
+	}
+	return v, true
+}

--- a/pkg/web/util.go
+++ b/pkg/web/util.go
@@ -15,24 +15,19 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// parseInt parses a given string to a 64bit integer.
-// If that fails a bad request status code is set in the gin context.
-func parseInt(ctx *gin.Context, s string) (int64, bool) {
-	v, err := strconv.ParseInt(s, 10, 64)
-	if err != nil {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return 0, false
-	}
-	return v, true
-}
+// toInt64 parses a given string to a 64bit integer.
+func toInt64(s string) (int64, error) { return strconv.ParseInt(s, 10, 64) }
 
-// parseBool parses a given string to a bool.
+// toBool parses a given string to a bool.
+var toBool = strconv.ParseBool
+
+// parse parses a string with a given function to a value.
 // If that fails a bad request status code is set in the gin context.
-func parseBool(ctx *gin.Context, s string) (bool, bool) {
-	v, err := strconv.ParseBool(s)
+func parse[T any](ctx *gin.Context, conv func(string) (T, error), s string) (T, bool) {
+	v, err := conv(s)
 	if err != nil {
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return false, false
+		return v, false
 	}
 	return v, true
 }


### PR DESCRIPTION
This PR reduces the boiler plate code like
```
idS := ctx.Param("id")
id, err := strconv.ParseInt(idS, 10, 64)
if err != nil {
    ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
    return
}
``` 
often found in the endpoints to
```
id, ok := parse(ctx, toInt64, ctx.Param("id"))
if !ok {
    return
}
```
It's not an optimal solution in any situation (we might have a look at Gin's bind feature in some cases),
but a little improvement concerning code duplication.