### PR TITLE
Product vulnerabilities

### DIFF
--- a/client/src/lib/Advisories/Advisory.svelte
+++ b/client/src/lib/Advisories/Advisory.svelte
@@ -35,6 +35,7 @@
   let loadEventsError = "";
   let loadAdvisoryVersionsError = "";
   let loadDocumentError = "";
+  let loadFourCVEsError = "";
   let createCommentError = "";
   let loadDocumentSSVCError = "";
   let stateError = "";
@@ -275,7 +276,22 @@
     }
   };
 
+  const loadFourCVEs = async () => {
+    const response = await request(
+      `/api/documents?advisories=true&columns=four_cves&query=$id ${params.id} integer =`,
+      "GET"
+    );
+    if (response.ok) {
+      const content = await response.content;
+      let four_cves = content?.documents[0]?.four_cves;
+      appStore.setFourCVEs(four_cves);
+    } else if (response.error) {
+      loadFourCVEsError = `Couldn't load CVEs. ${getErrorMessage(response.error)}`;
+    }
+  };
+
   const loadData = async () => {
+    await loadFourCVEs();
     await loadDocumentSSVC();
     await loadDocument();
     await loadAdvisoryVersions();
@@ -348,6 +364,7 @@
     <ErrorMessage message={loadDocumentSSVCError}></ErrorMessage>
     <ErrorMessage message={stateError}></ErrorMessage>
     <ErrorMessage message={loadDocumentError}></ErrorMessage>
+    <ErrorMessage message={loadFourCVEsError}></ErrorMessage>
     <div class="flex flex-row max-[800px]:flex-wrap-reverse">
       <div class="mr-12 flex w-2/3 flex-col">
         <div class="flex flex-row">

--- a/client/src/lib/Advisories/CSAFWebview/Webview.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/Webview.svelte
@@ -18,6 +18,7 @@
   import Notes from "./notes/Notes.svelte";
   import Acknowledgements from "./acknowledgements/Acknowledgements.svelte";
   import References from "./references/References.svelte";
+  import ProductVulnerabilities from "./productvulnerabilities/ProductVulnerabilities.svelte";
   $: aliases = $appStore.webview.doc?.aliases;
 
   $: isCSAF = !(
@@ -38,7 +39,17 @@
         <General />
       </div>
     {/if}
-
+    {#if $appStore.webview.doc?.productVulnerabilities.length > 1}
+      <Collapsible
+        header="Vulnerabilities overview"
+        open={$appStore.webview.ui.isVulnerabilitiesOverviewVisible}
+      >
+        <ProductVulnerabilities />
+      </Collapsible>
+    {:else}
+      <h2>No Vulnerabilities overview</h2>
+      (As no products are connected to vulnerabilities.)
+    {/if}
     {#if $appStore.webview.doc && $appStore.webview.doc["isProductTreePresent"]}
       <Collapsible
         header="Product tree"

--- a/client/src/lib/Advisories/CSAFWebview/productvulnerabilities/ProductVulnerabilities.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/productvulnerabilities/ProductVulnerabilities.svelte
@@ -18,7 +18,7 @@
     TableBody,
     TableBodyCell,
     TableBodyRow,
-    Toggle
+    Button
   } from "flowbite-svelte";
   const tdClass = "whitespace-nowrap py-1 px-2 font-normal";
   const tablePadding = "px-2";
@@ -66,7 +66,14 @@
   {#if productLines.length > 0}
     <div class="flex w-3/4 flex-col">
       <div class="crosstable">
-        <Toggle class="mb-3" bind:checked={renderAllCVEs}>Show all CVEs</Toggle>
+        <Button
+          color="light"
+          size="sm"
+          class={`mb-3 h-7 py-1 text-xs ${renderAllCVEs ? "bg-gray-200 hover:bg-gray-100" : ""}`}
+          on:click={() => {
+            renderAllCVEs = !renderAllCVEs;
+          }}>All CVEs</Button
+        >
         <Table noborder>
           <TableHead>
             {#each headerColumns as column, index}

--- a/client/src/lib/Advisories/CSAFWebview/productvulnerabilities/ProductVulnerabilities.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/productvulnerabilities/ProductVulnerabilities.svelte
@@ -62,127 +62,126 @@
   };
 </script>
 
-<div class="crosstable-overview mt-3 flex flex-row">
+<div class="crosstable-overview mb-3 mt-3 flex flex-col">
   {#if productLines.length > 0}
-    <div class="flex w-3/4 flex-col">
-      <div class="crosstable">
-        {#if productLines[0].length > 5}
-          <Button
-            color="light"
-            size="sm"
-            class={`mb-3 h-7 py-1 text-xs ${renderAllCVEs ? "bg-gray-200 hover:bg-gray-100" : ""}`}
-            on:click={() => {
-              renderAllCVEs = !renderAllCVEs;
-            }}>All CVEs</Button
-          >
-        {/if}
-        <Table noborder>
-          <TableHead>
-            {#each headerColumns as column, index}
-              {#if index == 0}
-                <TableHeadCell class="text-nowrap font-normal" padding={tablePadding}
-                  >{column.content}</TableHeadCell
-                >
-              {:else if index == 1}
-                <TableHeadCell class="text-nowrap font-normal" padding={tablePadding}
-                  >{column.content}</TableHeadCell
-                >
-              {:else if !renderAllCVEs && fourCVEs.includes(column.name)}
-                <TableHeadCell class="text-nowrap font-normal" padding={tablePadding}
-                  ><a id={crypto.randomUUID()} on:click={openCVE} href={column.content}
-                    >{column.content}</a
-                  ></TableHeadCell
-                >
-              {:else if renderAllCVEs}
-                <TableHeadCell class="text-nowrap font-normal" padding={tablePadding}
-                  ><a id={crypto.randomUUID()} on:click={openCVE} href={column.content}
-                    >{column.content}</a
-                  ></TableHeadCell
-                >
-              {/if}
-            {/each}
-          </TableHead>
-          <TableBody>
-            {#each productLines as line}
-              <TableBodyRow>
-                {#each line as column}
-                  {#if column.name === "Product"}
-                    <TableBodyCell {tdClass}
-                      ><a
-                        title={$appStore.webview.doc?.productsByID[column.content]}
-                        id={crypto.randomUUID()}
-                        on:click={openProduct}
-                        href={column.content}
-                        >{`${$appStore.webview.doc?.productsByID[column.content].substring(0, 20)}...`}
-                        ({column.content})</a
-                      ></TableBodyCell
-                    >
-                  {:else if column.content === "N.A" && ((!renderAllCVEs && fourCVEs.includes(column.name)) || column.name === "Total")}
-                    <TableBodyCell {tdClass}>{column.content}</TableBodyCell>
-                  {:else if column.content === "N.A" && renderAllCVEs && (fourCVEs.includes(column.name) || column.name === "Total")}
-                    <TableBodyCell {tdClass}>{column.content}</TableBodyCell>
-                  {:else if !renderAllCVEs && (fourCVEs.includes(column.name) || column.name === "Total")}
-                    <TableBodyCell {tdClass}>
-                      {#if column.content === ProductStatusSymbol.NOT_AFFECTED + ProductStatusSymbol.RECOMMENDED}
-                        <i class="bx bx-heart" />
-                        <i class="bx b-minus" />
-                      {:else}
-                        <i
-                          class:bx={true}
-                          class:bx-x={column.content === ProductStatusSymbol.KNOWN_AFFECTED}
-                          class:bx-check={column.content === ProductStatusSymbol.FIXED}
-                          class:bx-error={column.content ===
-                            ProductStatusSymbol.UNDER_INVESTIGATION}
-                          class:bx-minus={column.content === ProductStatusSymbol.NOT_AFFECTED}
-                          class:bx-heart={column.content === ProductStatusSymbol.RECOMMENDED}
-                        />
-                      {/if}
-                    </TableBodyCell>
-                  {:else if renderAllCVEs}
-                    <TableBodyCell {tdClass}>
-                      {#if column.content === ProductStatusSymbol.NOT_AFFECTED + ProductStatusSymbol.RECOMMENDED}
-                        <i class="bx bx-heart" />
-                        <i class="bx b-minus" />
-                      {:else}
-                        <i
-                          class:bx={true}
-                          class:bx-x={column.content === ProductStatusSymbol.KNOWN_AFFECTED}
-                          class:bx-check={column.content === ProductStatusSymbol.FIXED}
-                          class:bx-error={column.content ===
-                            ProductStatusSymbol.UNDER_INVESTIGATION}
-                          class:bx-minus={column.content === ProductStatusSymbol.NOT_AFFECTED}
-                          class:bx-heart={column.content === ProductStatusSymbol.RECOMMENDED}
-                        />
-                      {/if}
-                    </TableBodyCell>
-                  {/if}
-                {/each}
-              </TableBodyRow>
-            {/each}
-          </TableBody>
-        </Table>
+    <div class="mb-3 mt-3 flex flex-row">
+      {#if productLines[0].length > 1}
+        <Button
+          color="light"
+          size="sm"
+          class={`mr-3 h-7 py-1 text-xs ${renderAllCVEs ? "bg-gray-200 hover:bg-gray-100" : ""}`}
+          on:click={() => {
+            renderAllCVEs = !renderAllCVEs;
+          }}><span class="text-nowrap">All CVEs</span></Button
+        >
+      {/if}
+      <div class="flex flex-row items-baseline gap-4">
+        <div class="flex flex-row items-baseline">
+          <i class="bx bx-check" />
+          <span class="ml-1 text-nowrap">Fixed</span>
+        </div>
+        <div class="flex flex-row items-baseline">
+          <i class="bx bx-error" /><span class="ml-1 text-nowrap">Under investigation</span>
+        </div>
+        <div class="flex flex-row items-baseline">
+          <i class="bx bx-x" /><span class="ml-1 text-nowrap">Known affected</span>
+        </div>
+        <div class="flex flex-row items-baseline">
+          <i class="bx bx-minus" /><span class="ml-1 text-nowrap">Not affected</span>
+        </div>
+        <div class="flex flex-row items-baseline">
+          <i class="bx bx-heart" /><span class="ml-1 text-nowrap">Recommended</span>
+        </div>
       </div>
     </div>
-    <div class="ml-6 flex w-1/4 flex-col">
-      <h5>Legend</h5>
-      <div class="flex flex-col">
-        <div class="flex flex-row">
-          <i class="bx bx-check" />
-          <span class="ml-2 text-nowrap">Fixed</span>
-        </div>
-        <div class="flex flex-row">
-          <i class="bx bx-error" /><span class="ml-2 text-nowrap">Under investigation</span>
-        </div>
-        <div class="flex flex-row">
-          <i class="bx bx-x" /><span class="ml-2 text-nowrap">Known affected</span>
-        </div>
-        <div class="flex flex-row">
-          <i class="bx bx-minus" /><span class="ml-2 text-nowrap">Not affected</span>
-        </div>
-        <div class="flex flex-row">
-          <i class="bx bx-heart" /><span class="ml-2 text-nowrap">Recommended</span>
-        </div>
-      </div>
+    <div class="crosstable flex flex-row">
+      <Table noborder striped={true}>
+        <TableHead>
+          {#each headerColumns as column, index}
+            {#if index == 0}
+              <TableHeadCell class="text-nowrap font-normal" padding={tablePadding}
+                >{column.content}</TableHeadCell
+              >
+            {:else if index == 1}
+              <TableHeadCell class="text-nowrap font-normal" padding={tablePadding}
+                >{column.content}</TableHeadCell
+              >
+            {:else if !renderAllCVEs && fourCVEs.includes(column.name)}
+              <TableHeadCell class="text-nowrap font-normal" padding={tablePadding}
+                ><a id={crypto.randomUUID()} on:click={openCVE} href={column.content}
+                  >{column.content}</a
+                ></TableHeadCell
+              >
+            {:else if renderAllCVEs}
+              <TableHeadCell class="text-nowrap font-normal" padding={tablePadding}
+                ><a id={crypto.randomUUID()} on:click={openCVE} href={column.content}
+                  >{column.content}</a
+                ></TableHeadCell
+              >
+            {/if}
+          {/each}
+        </TableHead>
+        <TableBody>
+          {#each productLines as line}
+            <TableBodyRow>
+              {#each line as column}
+                {#if column.name === "Product"}
+                  <TableBodyCell {tdClass}
+                    ><a
+                      title={$appStore.webview.doc?.productsByID[column.content]}
+                      id={crypto.randomUUID()}
+                      on:click={openProduct}
+                      href={column.content}
+                      >{$appStore.webview.doc?.productsByID[column.content].length > 20
+                        ? `${$appStore.webview.doc?.productsByID[column.content].substring(0, 20)}...`
+                        : `${$appStore.webview.doc?.productsByID[column.content]}`}
+                      ({column.content.length > 20
+                        ? column.content.substring(0, 20)
+                        : column.content})</a
+                    ></TableBodyCell
+                  >
+                {:else if column.content === "N.A" && ((!renderAllCVEs && fourCVEs.includes(column.name)) || column.name === "Total")}
+                  <TableBodyCell {tdClass}>{column.content}</TableBodyCell>
+                {:else if column.content === "N.A" && renderAllCVEs && (fourCVEs.includes(column.name) || column.name === "Total")}
+                  <TableBodyCell {tdClass}>{column.content}</TableBodyCell>
+                {:else if !renderAllCVEs && (fourCVEs.includes(column.name) || column.name === "Total")}
+                  <TableBodyCell {tdClass}>
+                    {#if column.content === ProductStatusSymbol.NOT_AFFECTED + ProductStatusSymbol.RECOMMENDED}
+                      <i class="bx bx-heart" />
+                      <i class="bx b-minus" />
+                    {:else}
+                      <i
+                        class:bx={true}
+                        class:bx-x={column.content === ProductStatusSymbol.KNOWN_AFFECTED}
+                        class:bx-check={column.content === ProductStatusSymbol.FIXED}
+                        class:bx-error={column.content === ProductStatusSymbol.UNDER_INVESTIGATION}
+                        class:bx-minus={column.content === ProductStatusSymbol.NOT_AFFECTED}
+                        class:bx-heart={column.content === ProductStatusSymbol.RECOMMENDED}
+                      />
+                    {/if}
+                  </TableBodyCell>
+                {:else if renderAllCVEs}
+                  <TableBodyCell {tdClass}>
+                    {#if column.content === ProductStatusSymbol.NOT_AFFECTED + ProductStatusSymbol.RECOMMENDED}
+                      <i class="bx bx-heart" />
+                      <i class="bx b-minus" />
+                    {:else}
+                      <i
+                        class:bx={true}
+                        class:bx-x={column.content === ProductStatusSymbol.KNOWN_AFFECTED}
+                        class:bx-check={column.content === ProductStatusSymbol.FIXED}
+                        class:bx-error={column.content === ProductStatusSymbol.UNDER_INVESTIGATION}
+                        class:bx-minus={column.content === ProductStatusSymbol.NOT_AFFECTED}
+                        class:bx-heart={column.content === ProductStatusSymbol.RECOMMENDED}
+                      />
+                    {/if}
+                  </TableBodyCell>
+                {/if}
+              {/each}
+            </TableBodyRow>
+          {/each}
+        </TableBody>
+      </Table>
     </div>
   {/if}
 </div>

--- a/client/src/lib/Advisories/CSAFWebview/productvulnerabilities/ProductVulnerabilities.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/productvulnerabilities/ProductVulnerabilities.svelte
@@ -23,11 +23,8 @@
   const tdClass = "whitespace-nowrap py-1 px-2 font-normal";
   const tablePadding = "px-2";
   let renderAllCVEs = false;
-  let PRODUCT_AND_TOTAL = 2;
-  let CVES_TO_RENDER = 1;
-  let MIN_CVES = PRODUCT_AND_TOTAL + CVES_TO_RENDER;
-  let headerColumns: string[] = [];
-  let productLines: string[][];
+  let headerColumns: any[] = [];
+  let productLines: any[] = [];
 
   $: if ($appStore.webview.doc) {
     const vulnerabilities = [...$appStore.webview.doc.productVulnerabilities];
@@ -36,7 +33,7 @@
     productLines = vulnerabilities;
   }
 
-  // $: fourCVEs = $appStore.webview.four_cves;
+  $: fourCVEs = $appStore.webview.four_cves;
 
   /**
    * openProduct opens the according product given via href.
@@ -69,33 +66,37 @@
   {#if productLines.length > 0}
     <div class="flex w-3/4 flex-col">
       <div class="crosstable">
-        <Button
-          color="light"
-          size="sm"
-          class={`mb-3 h-7 py-1 text-xs ${renderAllCVEs ? "bg-gray-200 hover:bg-gray-100" : ""}`}
-          on:click={() => {
-            renderAllCVEs = !renderAllCVEs;
-          }}>All CVEs</Button
-        >
+        {#if productLines[0].length > 5}
+          <Button
+            color="light"
+            size="sm"
+            class={`mb-3 h-7 py-1 text-xs ${renderAllCVEs ? "bg-gray-200 hover:bg-gray-100" : ""}`}
+            on:click={() => {
+              renderAllCVEs = !renderAllCVEs;
+            }}>All CVEs</Button
+          >
+        {/if}
         <Table noborder>
           <TableHead>
             {#each headerColumns as column, index}
               {#if index == 0}
                 <TableHeadCell class="text-nowrap font-normal" padding={tablePadding}
-                  >{column}</TableHeadCell
+                  >{column.content}</TableHeadCell
                 >
               {:else if index == 1}
                 <TableHeadCell class="text-nowrap font-normal" padding={tablePadding}
-                  >{column}</TableHeadCell
+                  >{column.content}</TableHeadCell
                 >
-              {:else if !renderAllCVEs && index < MIN_CVES}
+              {:else if !renderAllCVEs && fourCVEs.includes(column.name)}
                 <TableHeadCell class="text-nowrap font-normal" padding={tablePadding}
-                  ><a id={crypto.randomUUID()} on:click={openCVE} href={column}>{column}</a
+                  ><a id={crypto.randomUUID()} on:click={openCVE} href={column.content}
+                    >{column.content}</a
                   ></TableHeadCell
                 >
               {:else if renderAllCVEs}
                 <TableHeadCell class="text-nowrap font-normal" padding={tablePadding}
-                  ><a id={crypto.randomUUID()} on:click={openCVE} href={column}>{column}</a
+                  ><a id={crypto.randomUUID()} on:click={openCVE} href={column.content}
+                    >{column.content}</a
                   ></TableHeadCell
                 >
               {/if}
@@ -104,50 +105,53 @@
           <TableBody>
             {#each productLines as line}
               <TableBodyRow>
-                {#each line as column, index}
-                  {#if index < 1}
+                {#each line as column}
+                  {#if column.name === "Product"}
                     <TableBodyCell {tdClass}
                       ><a
-                        title={$appStore.webview.doc?.productsByID[column]}
+                        title={$appStore.webview.doc?.productsByID[column.content]}
                         id={crypto.randomUUID()}
                         on:click={openProduct}
-                        href={column}
-                        >{`${$appStore.webview.doc?.productsByID[column].substring(0, 20)}...`} ({column})</a
+                        href={column.content}
+                        >{`${$appStore.webview.doc?.productsByID[column.content].substring(0, 20)}...`}
+                        ({column.content})</a
                       ></TableBodyCell
                     >
-                  {:else if column === "N.A" && !renderAllCVEs && index < MIN_CVES}
-                    <TableBodyCell {tdClass}>{column}</TableBodyCell>
-                  {:else if column === "N.A" && renderAllCVEs && index < MIN_CVES}
-                    <TableBodyCell {tdClass}>{column}</TableBodyCell>
-                  {:else if !renderAllCVEs && index < MIN_CVES}
+                  {:else if column.content === "N.A" && ((!renderAllCVEs && fourCVEs.includes(column.name)) || column.name === "Total")}
+                    <TableBodyCell {tdClass}>{column.content}</TableBodyCell>
+                  {:else if column.content === "N.A" && renderAllCVEs && (fourCVEs.includes(column.name) || column.name === "Total")}
+                    <TableBodyCell {tdClass}>{column.content}</TableBodyCell>
+                  {:else if !renderAllCVEs && (fourCVEs.includes(column.name) || column.name === "Total")}
                     <TableBodyCell {tdClass}>
-                      {#if column === ProductStatusSymbol.NOT_AFFECTED + ProductStatusSymbol.RECOMMENDED}
+                      {#if column.content === ProductStatusSymbol.NOT_AFFECTED + ProductStatusSymbol.RECOMMENDED}
                         <i class="bx bx-heart" />
                         <i class="bx b-minus" />
                       {:else}
                         <i
                           class:bx={true}
-                          class:bx-x={column === ProductStatusSymbol.KNOWN_AFFECTED}
-                          class:bx-check={column === ProductStatusSymbol.FIXED}
-                          class:bx-error={column === ProductStatusSymbol.UNDER_INVESTIGATION}
-                          class:bx-minus={column === ProductStatusSymbol.NOT_AFFECTED}
-                          class:bx-heart={column === ProductStatusSymbol.RECOMMENDED}
+                          class:bx-x={column.content === ProductStatusSymbol.KNOWN_AFFECTED}
+                          class:bx-check={column.content === ProductStatusSymbol.FIXED}
+                          class:bx-error={column.content ===
+                            ProductStatusSymbol.UNDER_INVESTIGATION}
+                          class:bx-minus={column.content === ProductStatusSymbol.NOT_AFFECTED}
+                          class:bx-heart={column.content === ProductStatusSymbol.RECOMMENDED}
                         />
                       {/if}
                     </TableBodyCell>
                   {:else if renderAllCVEs}
                     <TableBodyCell {tdClass}>
-                      {#if column === ProductStatusSymbol.NOT_AFFECTED + ProductStatusSymbol.RECOMMENDED}
+                      {#if column.content === ProductStatusSymbol.NOT_AFFECTED + ProductStatusSymbol.RECOMMENDED}
                         <i class="bx bx-heart" />
                         <i class="bx b-minus" />
                       {:else}
                         <i
                           class:bx={true}
-                          class:bx-x={column === ProductStatusSymbol.KNOWN_AFFECTED}
-                          class:bx-check={column === ProductStatusSymbol.FIXED}
-                          class:bx-error={column === ProductStatusSymbol.UNDER_INVESTIGATION}
-                          class:bx-minus={column === ProductStatusSymbol.NOT_AFFECTED}
-                          class:bx-heart={column === ProductStatusSymbol.RECOMMENDED}
+                          class:bx-x={column.content === ProductStatusSymbol.KNOWN_AFFECTED}
+                          class:bx-check={column.content === ProductStatusSymbol.FIXED}
+                          class:bx-error={column.content ===
+                            ProductStatusSymbol.UNDER_INVESTIGATION}
+                          class:bx-minus={column.content === ProductStatusSymbol.NOT_AFFECTED}
+                          class:bx-heart={column.content === ProductStatusSymbol.RECOMMENDED}
                         />
                       {/if}
                     </TableBodyCell>

--- a/client/src/lib/Advisories/CSAFWebview/productvulnerabilities/ProductVulnerabilities.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/productvulnerabilities/ProductVulnerabilities.svelte
@@ -35,6 +35,9 @@
     headerColumns = vulnerabilities.shift()!;
     productLines = vulnerabilities;
   }
+
+  // $: fourCVEs = $appStore.webview.four_cves;
+
   /**
    * openProduct opens the according product given via href.
    * @param e

--- a/client/src/lib/Advisories/CSAFWebview/productvulnerabilities/ProductVulnerabilities.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/productvulnerabilities/ProductVulnerabilities.svelte
@@ -9,6 +9,7 @@
 -->
 
 <script lang="ts">
+  import { onMount } from "svelte";
   import { appStore } from "$lib/store";
   import { ProductStatusSymbol } from "./productvulnerabilitiestypes";
   import {
@@ -25,6 +26,11 @@
   let renderAllCVEs = false;
   let headerColumns: any[] = [];
   let productLines: any[] = [];
+
+  onMount(() => {
+    appStore.setProductTreeSectionInVisible();
+    appStore.resetSelectedProduct();
+  })
 
   $: if ($appStore.webview.doc) {
     const vulnerabilities = [...$appStore.webview.doc.productVulnerabilities];

--- a/client/src/lib/Advisories/CSAFWebview/productvulnerabilities/ProductVulnerabilities.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/productvulnerabilities/ProductVulnerabilities.svelte
@@ -30,7 +30,7 @@
   onMount(() => {
     appStore.setProductTreeSectionInVisible();
     appStore.resetSelectedProduct();
-  })
+  });
 
   $: if ($appStore.webview.doc) {
     const vulnerabilities = [...$appStore.webview.doc.productVulnerabilities];

--- a/client/src/lib/Advisories/CSAFWebview/productvulnerabilities/ProductVulnerabilities.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/productvulnerabilities/ProductVulnerabilities.svelte
@@ -65,16 +65,6 @@
 <div class="crosstable-overview mb-3 mt-3 flex flex-col">
   {#if productLines.length > 0}
     <div class="mb-3 mt-3 flex flex-row">
-      {#if productLines[0].length > 1}
-        <Button
-          color="light"
-          size="sm"
-          class={`mr-3 h-7 py-1 text-xs ${renderAllCVEs ? "bg-gray-200 hover:bg-gray-100" : ""}`}
-          on:click={() => {
-            renderAllCVEs = !renderAllCVEs;
-          }}><span class="text-nowrap">All CVEs</span></Button
-        >
-      {/if}
       <div class="flex flex-row items-baseline gap-4">
         <div class="flex flex-row items-baseline">
           <i class="bx bx-check" />
@@ -92,6 +82,18 @@
         <div class="flex flex-row items-baseline">
           <i class="bx bx-heart" /><span class="ml-1 text-nowrap">Recommended</span>
         </div>
+        {#if productLines[0].length > 6}
+          <div class="flex flex-row items-baseline">
+            <Button
+              color="light"
+              size="sm"
+              class={`mr-3 h-7 py-1 text-xs ${renderAllCVEs ? "bg-gray-200 hover:bg-gray-100" : ""}`}
+              on:click={() => {
+                renderAllCVEs = !renderAllCVEs;
+              }}><span class="text-nowrap">All CVEs ({productLines[0].length - 2})</span></Button
+            >
+          </div>
+        {/if}
       </div>
     </div>
     <div class="crosstable flex flex-row">

--- a/client/src/lib/Advisories/CSAFWebview/productvulnerabilities/productvulnerabilities.test.ts
+++ b/client/src/lib/Advisories/CSAFWebview/productvulnerabilities/productvulnerabilities.test.ts
@@ -341,7 +341,7 @@ describe("Productvulnerabilities test", () => {
       return o;
     }, {});
     const result = generateProductVulnerabilities(jsonDocument, products, productLookup);
-    const header = result[0];
+    const header = result[0].map((c: any) => c.content);
     const expectedHeader = [
       "Product",
       "Total result",
@@ -377,41 +377,41 @@ describe("Productvulnerabilities test", () => {
     const CVE_2020_0174_COLUMN = 5;
     expect(result.length).toBe(6);
     // Product A
-    expect(line1[PRODUCT_COLUMN]).toBe("123");
-    expect(line1[TOTAL_COLUMN]).toBe("K");
-    expect(line1[CVE_2016_0173_COLUMN]).toBe("");
-    expect(line1[CVE_2018_0172_COLUMN]).toBe("");
-    expect(line1[CVE_2019_0171_COLUMN]).toBe(ProductStatusSymbol.KNOWN_AFFECTED);
-    expect(line1[CVE_2020_0174_COLUMN]).toBe("");
+    expect(line1[PRODUCT_COLUMN].content).toBe("123");
+    expect(line1[TOTAL_COLUMN].content).toBe("K");
+    expect(line1[CVE_2016_0173_COLUMN].content).toBe("");
+    expect(line1[CVE_2018_0172_COLUMN].content).toBe("");
+    expect(line1[CVE_2019_0171_COLUMN].content).toBe(ProductStatusSymbol.KNOWN_AFFECTED);
+    expect(line1[CVE_2020_0174_COLUMN].content).toBe("");
     // Product B
-    expect(line2[PRODUCT_COLUMN]).toBe("3456");
-    expect(line2[TOTAL_COLUMN]).toBe("K");
-    expect(line2[CVE_2016_0173_COLUMN]).toBe("");
-    expect(line2[CVE_2018_0172_COLUMN]).toBe("");
-    expect(line2[CVE_2019_0171_COLUMN]).toBe(ProductStatusSymbol.KNOWN_AFFECTED);
-    expect(line2[CVE_2020_0174_COLUMN]).toBe("");
+    expect(line2[PRODUCT_COLUMN].content).toBe("3456");
+    expect(line2[TOTAL_COLUMN].content).toBe("K");
+    expect(line2[CVE_2016_0173_COLUMN].content).toBe("");
+    expect(line2[CVE_2018_0172_COLUMN].content).toBe("");
+    expect(line2[CVE_2019_0171_COLUMN].content).toBe(ProductStatusSymbol.KNOWN_AFFECTED);
+    expect(line2[CVE_2020_0174_COLUMN].content).toBe("");
     // Product C
-    expect(line3[PRODUCT_COLUMN]).toBe("8910");
-    expect(line3[TOTAL_COLUMN]).toBe("K");
-    expect(line3[CVE_2016_0173_COLUMN]).toBe("");
-    expect(line3[CVE_2018_0172_COLUMN]).toBe(ProductStatusSymbol.KNOWN_AFFECTED);
-    expect(line3[CVE_2019_0171_COLUMN]).toBe("");
-    expect(line3[CVE_2020_0174_COLUMN]).toBe("");
+    expect(line3[PRODUCT_COLUMN].content).toBe("8910");
+    expect(line3[TOTAL_COLUMN].content).toBe("K");
+    expect(line3[CVE_2016_0173_COLUMN].content).toBe("");
+    expect(line3[CVE_2018_0172_COLUMN].content).toBe(ProductStatusSymbol.KNOWN_AFFECTED);
+    expect(line3[CVE_2019_0171_COLUMN].content).toBe("");
+    expect(line3[CVE_2020_0174_COLUMN].content).toBe("");
     // Product D
-    expect(line4[PRODUCT_COLUMN]).toBe("1112");
-    expect(line4[TOTAL_COLUMN]).toBe("F");
-    expect(line4[CVE_2016_0173_COLUMN]).toBe("");
-    expect(line4[CVE_2018_0172_COLUMN]).toBe("");
-    expect(line4[CVE_2019_0171_COLUMN]).toBe("");
-    expect(line4[CVE_2020_0174_COLUMN]).toBe(ProductStatusSymbol.FIXED);
+    expect(line4[PRODUCT_COLUMN].content).toBe("1112");
+    expect(line4[TOTAL_COLUMN].content).toBe("F");
+    expect(line4[CVE_2016_0173_COLUMN].content).toBe("");
+    expect(line4[CVE_2018_0172_COLUMN].content).toBe("");
+    expect(line4[CVE_2019_0171_COLUMN].content).toBe("");
+    expect(line4[CVE_2020_0174_COLUMN].content).toBe(ProductStatusSymbol.FIXED);
     //Product E
-    expect(line5[PRODUCT_COLUMN]).toBe("1314");
-    expect(line5[TOTAL_COLUMN]).toBe("N");
-    expect(line5[CVE_2016_0173_COLUMN]).toBe(
+    expect(line5[PRODUCT_COLUMN].content).toBe("1314");
+    expect(line5[TOTAL_COLUMN].content).toBe("N");
+    expect(line5[CVE_2016_0173_COLUMN].content).toBe(
       ProductStatusSymbol.NOT_AFFECTED + ProductStatusSymbol.RECOMMENDED
     );
-    expect(line5[CVE_2018_0172_COLUMN]).toBe("");
-    expect(line5[CVE_2019_0171_COLUMN]).toBe("");
-    expect(line5[CVE_2020_0174_COLUMN]).toBe("");
+    expect(line5[CVE_2018_0172_COLUMN].content).toBe("");
+    expect(line5[CVE_2019_0171_COLUMN].content).toBe("");
+    expect(line5[CVE_2020_0174_COLUMN].content).toBe("");
   });
 });

--- a/client/src/lib/Advisories/CSAFWebview/productvulnerabilities/productvulnerabilities.ts
+++ b/client/src/lib/Advisories/CSAFWebview/productvulnerabilities/productvulnerabilities.ts
@@ -109,7 +109,7 @@ const generateCrossTableFrom = (
   });
   productLines.sort((line1: any, line2: any) => {
     if (productLookup[line1[0].content] < productLookup[line2[0].content]) return -1;
-    if (productLookup[line1[0].content] > productLookup[line2[0]].content) return 1;
+    if (productLookup[line1[0].content] > productLookup[line2[0].content]) return 1;
     return 0;
   });
   result = [...result, ...productLines];

--- a/client/src/lib/store.ts
+++ b/client/src/lib/store.ts
@@ -47,6 +47,7 @@ type AppStore = {
     doc: DocModel | null;
     providerMetadata: any;
     currentFeed: any;
+    four_cves: any;
     ui: {
       docToggleExpandAll: boolean;
       feedErrorMsg: string;
@@ -99,6 +100,7 @@ const generateInitialState = (): AppStore => {
       doc: null,
       providerMetadata: null,
       currentFeed: null,
+      four_cves: [],
       ui: {
         docToggleExpandAll: false,
         feedErrorMsg: "",
@@ -126,6 +128,18 @@ function createStore() {
   subscribe((v) => (state = v));
   return {
     subscribe,
+    setFourCVEs: (cves: any) => {
+      update((settings) => {
+        settings.webview.four_cves = cves;
+        return settings;
+      });
+    },
+    clearFourCVEs: () => {
+      update((settings) => {
+        settings.webview.four_cves = [];
+        return settings;
+      });
+    },
     setSessionExpired: (expired: boolean) => {
       update((settings) => {
         settings.app.sessionExpired = expired;


### PR DESCRIPTION
Re-introduces the product vulnerability crosstable.

New:

There are now two modes:

- Display only the CVEs which are _relevant for display_ recurring on the implementation of the `four_cves` column 
- Full display of all products ⨯ vulnerabilities

Legend is now on top  instead of right.

This is a (small) improvement to the status quo.