### PR TITLE
improve top level licensing information

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 # ISDuBA
 
-**Work in progress** **pre-alpha**
+**Under development - some things already work**
 
 A web application
 for downloading and evaluating security advisories in CSAF 2.0 format.
@@ -39,6 +39,39 @@ ISDuBA uses the following components:
 The abbreviation expands to a German label, which translates to
   **I**nternal **s**ystem for **d**ownloading and evaluating **a**dvisories.
 
-## Free Software
 
-ISDuBA is Free Software licensed under the terms of the [Apache License, Version 2.0](./LICENSES/Apache-2.0.txt).
+## License
+
+ISDuBA is Free Software.
+
+Source code written for ISDuBA was placed under the
+[Apache License, Version 2.0](./LICENSES/Apache-2.0.txt).
+
+```
+ SPDX-License-Identifier: Apache-2.0
+
+ SPDX-FileCopyrightText: 2024 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+ Software-Engineering: 2024 Intevation GmbH <https://intevation.de>
+```
+
+ISDuBA depends on third party Free Software components which have their
+own right holders and licenses. To our best knowledge
+(at the time when they have been added)
+the dependencies are upwards compatible with the ISDuBA main license.
+
+### Dependencies
+
+The top level dependencies can be seen from
+ * [go.mod](./go.mod) for the `isduad` backend and server tools.
+ * [package.json](./client/package.json) for the web application frontend.
+ * The build and setup descriptions (linked above).
+
+Use one of several available Free Software tools to examine indirect
+dependencies and get a more complete list of component names and licenses.
+
+For example use the SPDX-2.3 SBOM json file coming with an ISDuBA release
+or use https://github.com/anchore/syft to create one.
+Then run [list_licenses.py](./docs/scripts/list_licenses.py)
+or `python3 -m json.tool` on it to see more.
+
+

--- a/docs/scripts/list_licenses.py
+++ b/docs/scripts/list_licenses.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Extract licensing info from the packages of an SPDX-2.3 SBOM JSON file.
+
+An experimental example for the output of Github Action
+anchore/sbom-action@v0 with: format: spdx-json output.
+
+Give a filename to that output as parameter.
+
+
+SPDX-License-Identifier: Apache-2.0
+
+SPDX-FileCopyrightText: 2024 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+Software-Engineering: 2024 Intevation GmbH <https://intevation.de>
+"""
+import json
+import sys
+
+if len(sys.argv) != 2:
+    sys.exit(__doc__)
+
+with open(sys.argv[1], 'rt', encoding="utf-8") as file:
+    sbom = json.load(file)
+
+    if sbom["SPDXID"] != "SPDXRef-DOCUMENT" or \
+       sbom["spdxVersion"] != "SPDX-2.3":
+        sys.exit("Not an SPDX-2.3 SBOM file")
+
+    for p in sbom["packages"]:
+        l = p["licenseConcluded"]
+        if l == "NOASSERTION":
+            l = p["licenseDeclared"]
+
+        print("{},{}".format(p["name"], l))


### PR DESCRIPTION
 * Expand section in the README.md to list the places where the top level dependencies are listed and to give one way how to get a more complete list.
 * Add an example script to examine the SPDX-2.3 JSON SBOM file that we are creating with releases.
 * Mark the overal status as "under developmend - some things already work".

resolve #275