### PR TITLE
Allow to fetch all comments and events for an advisory

### DIFF
--- a/pkg/models/advisory.go
+++ b/pkg/models/advisory.go
@@ -1,0 +1,22 @@
+// This file is Free Software under the Apache-2.0 License
+// without warranty, see README.md and LICENSES/Apache-2.0.txt for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: 2024 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+// Software-Engineering: 2024 Intevation GmbH <https://intevation.de>
+
+package models
+
+// AdvisoryKey specifies a unique advisory.
+type AdvisoryKey struct {
+	Publisher  string `uri:"publisher" binding:"required" json:"publisher"`
+	TrackingID string `uri:"trackingid" binding:"required" json:"tracking_id"`
+}
+
+// AdvisoryState specifies a unique advisory with its state.
+type AdvisoryState struct {
+	Publisher  string   `uri:"publisher" binding:"required" json:"publisher"`
+	TrackingID string   `uri:"trackingid" binding:"required" json:"tracking_id"`
+	State      Workflow `uri:"state" binding:"required" json:"state"`
+}

--- a/pkg/web/advisory.go
+++ b/pkg/web/advisory.go
@@ -22,18 +22,7 @@ import (
 	"github.com/ISDuBA/ISDuBA/pkg/models"
 )
 
-type advisoryKey struct {
-	Publisher  string `uri:"publisher" binding:"required" json:"publisher"`
-	TrackingID string `uri:"trackingid" binding:"required" json:"tracking_id"`
-}
-
-type advisoryState struct {
-	Publisher  string          `uri:"publisher" binding:"required" json:"publisher"`
-	TrackingID string          `uri:"trackingid" binding:"required" json:"tracking_id"`
-	State      models.Workflow `uri:"state" binding:"required" json:"state"`
-}
-
-type advisoryStates []advisoryState
+type advisoryStates []models.AdvisoryState
 
 func (c *Controller) changeStatusAll(ctx *gin.Context, inputs advisoryStates) {
 	const (
@@ -141,7 +130,7 @@ func (c *Controller) changeStatusAll(ctx *gin.Context, inputs advisoryStates) {
 }
 
 func (c *Controller) changeStatus(ctx *gin.Context) {
-	var input advisoryState
+	var input models.AdvisoryState
 	if err := ctx.ShouldBindUri(&input); err != nil {
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
@@ -160,7 +149,7 @@ func (c *Controller) changeStatusBulk(ctx *gin.Context) {
 
 // deleteAdvisory deletes a given advisory.
 func (c *Controller) deleteAdvisory(ctx *gin.Context) {
-	var key advisoryKey
+	var key models.AdvisoryKey
 	if err := ctx.ShouldBindUri(&key); err != nil {
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
@@ -221,14 +210,14 @@ func (c *Controller) deleteAdvisory(ctx *gin.Context) {
 		if errors.Is(err, pgx.ErrNoRows) {
 			ctx.JSON(http.StatusNotFound, gin.H{"error": "advisory not found"})
 		} else {
-			slog.Error("deleting adviory failed", "err", err)
+			slog.Error("deleting advisory failed", "err", err)
 			ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		}
 		return
 	}
 	switch {
 	case forbidden:
-		ctx.JSON(http.StatusForbidden, gin.H{"error": "not allowed to delete adviory"})
+		ctx.JSON(http.StatusForbidden, gin.H{"error": "not allowed to delete advisory"})
 	case !deleted:
 		ctx.JSON(http.StatusNotFound, gin.H{"error": "advisory not found"})
 	default:

--- a/pkg/web/controller.go
+++ b/pkg/web/controller.go
@@ -103,7 +103,7 @@ func (c *Controller) Bind() http.Handler {
 
 	// Comments
 	api.POST("/comments/:document", authEdRe, c.createComment)
-	api.GET("/comments/:document", authEdReAu, c.viewComments)
+	api.GET("/comments/:publisher/:trackingid", authEdReAu, c.viewComments)
 	api.PUT("/comments/post/:id", authEdRe, c.updateComment)
 	api.GET("/comments/post/:id", authEdReAu, c.viewComment)
 
@@ -116,7 +116,7 @@ func (c *Controller) Bind() http.Handler {
 
 	// Events
 	api.GET("/events", authEdReAu, c.overviewEvents)
-	api.GET("/events/:document", authEdReAu, c.viewEvents)
+	api.GET("/events/:publisher/:trackingid", authEdReAu, c.viewEvents)
 
 	// State change
 	api.PUT("/status/:publisher/:trackingid/:state", authEdReAd, c.changeStatus)


### PR DESCRIPTION
This avoids the client having to make multiple requests and simplifies error handling.