### PR TITLE
Proxy for loading provider metadata

### DIFF
--- a/pkg/sources/sources.go
+++ b/pkg/sources/sources.go
@@ -28,7 +28,8 @@ import (
 	"golang.org/x/time/rate"
 )
 
-var userAgent = "isduba/" + version.SemVersion
+// UserAgent is the name of the http client
+var UserAgent = "isduba/" + version.SemVersion
 
 type state int
 
@@ -283,7 +284,7 @@ func (s *source) httpClient() *http.Client {
 
 // doRequest executes an HTTP request with the source specific parameters.
 func (s *source) doRequest(req *http.Request) (*http.Response, error) {
-	req.Header.Add("User-Agent", userAgent)
+	req.Header.Add("User-Agent", UserAgent)
 
 	// TODO: Implement me!
 	client := s.httpClient()

--- a/pkg/web/controller.go
+++ b/pkg/web/controller.go
@@ -143,6 +143,9 @@ func (c *Controller) Bind() http.Handler {
 	// Client configuration
 	api.GET("/client-config", c.clientConfig)
 
+	// PMD proxy
+	api.GET("/pmd", authSM, c.pmd)
+
 	// Source manager
 	api.GET("/sources", authEdSM, c.viewSources)
 	api.POST("/sources", authSM, c.createSource)

--- a/pkg/web/pmd.go
+++ b/pkg/web/pmd.go
@@ -1,0 +1,49 @@
+// This file is Free Software under the Apache-2.0 License
+// without warranty, see README.md and LICENSES/Apache-2.0.txt for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: 2024 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+// Software-Engineering: 2024 Intevation GmbH <https://intevation.de>
+
+package web
+
+import (
+	"net/http"
+
+	"github.com/ISDuBA/ISDuBA/pkg/sources"
+	"github.com/csaf-poc/csaf_distribution/v3/csaf"
+	"github.com/csaf-poc/csaf_distribution/v3/util"
+	"github.com/gin-gonic/gin"
+)
+
+func (c *Controller) pmd(ctx *gin.Context) {
+	var input struct {
+		URL string `form:"url" binding:"required,min=1"`
+	}
+	if err := ctx.ShouldBindQuery(&input); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	header := http.Header{}
+	header.Add("User-Agent", sources.UserAgent)
+	client := util.HeaderClient{
+		Client: &http.Client{},
+		Header: header,
+	}
+	pmdLoader := csaf.NewProviderMetadataLoader(&client)
+	lpmd := pmdLoader.Load(input.URL)
+	if !lpmd.Valid() {
+		h := gin.H{}
+		if n := len(lpmd.Messages); n > 0 {
+			msgs := make([]string, 0, n)
+			for i := range lpmd.Messages {
+				msgs = append(msgs, lpmd.Messages[i].Message)
+			}
+			h["messages"] = msgs
+		}
+		ctx.JSON(http.StatusBadGateway, h)
+		return
+	}
+	ctx.JSON(http.StatusOK, lpmd.Document)
+}


### PR DESCRIPTION
Enables `source-manager` role to load PMDs into client.
e.g.
```
curl -s -D /dev/stderr -X GET \
   -H "Authorization: Bearer $TOKEN" \
   http://localhost:8081/api/pmd\?url\=siemens.com | jq .
```

Allowed are domains and urls directly pointing to PMDs-