### PR TITLE
Source manager: Add  timeout to HTTP requests

### DIFF
--- a/docs/example_isdubad.toml
+++ b/docs/example_isdubad.toml
@@ -67,6 +67,7 @@
 #                      please contact your CSAF source manager \
 #                      or your administrator."""
 # aes_key = ""
+# timeout = "30s"
 
 # [remote_validator]
 # url = ""

--- a/docs/isdubad-config.md
+++ b/docs/isdubad-config.md
@@ -93,7 +93,7 @@ Valid values for `tlps` are the [Traffic Light Protocol](https://en.wikipedia.or
 
 - `files_total`: Max number of files hold in temp storage. Defaults to `10`.
 - `files_user`: Max number of files hold in temp storage per user. Defaults to `2`.
-- `storage_duration`: Ensured storage duration in temp storage. Defaults to `"30m"` minutes.
+- `storage_duration`: Ensured storage duration in temp storage. Defaults to `"30m"`.
 
 ### <a name="section_sources"></a> Section `[sources]` Sources
 
@@ -103,9 +103,9 @@ Valid values for `tlps` are the [Traffic Light Protocol](https://en.wikipedia.or
 - `download_slots`: The number of concurrent downloads from the sources. Defaults to `100`.
 - `max_slots_per_source`: The number of concurrent downloads per source. Defaults to `2`.
 - `max_rate_per_source`: The Number of requests per source per second. Defaults to `0` (unlimited).
-- `openpgp_caching`: Determines how long OpenPGP keys are kept for signature checking. Defaults to `24h`.
-- `feed_refresh`: Duration between re-asking source for a new updated feed index. Defaults to `15m`.
-- `feed_log_level`: The log level per feed. Valid values are `debug`, `info`, `warn`, `error`. Defaults to `info`.
+- `openpgp_caching`: Determines how long OpenPGP keys are kept for signature checking. Defaults to `"24h"`.
+- `feed_refresh`: Duration between re-asking source for a new updated feed index. Defaults to `"15m"`.
+- `feed_log_level`: The log level per feed. Valid values are `debug`, `info`, `warn`, `error`. Defaults to `"info"`.
 - `feed_importer`: Name of the user that is doing the feed imports. Defaults to `feedimporter`.
 - `publishers_tlps`: Rules what the feed import is allowed to import. Defaults to `{ "*" = [ "WHITE", "GREEN", "AMBER", "RED" ] }`
 - `default_message`: The message that should be displayed inside the source manager.
@@ -117,6 +117,7 @@ Valid values for `tlps` are the [Traffic Light Protocol](https://en.wikipedia.or
    in this option prefixed by `@`.\
    You can generate a token yourself e.g. by entering this command:\
    `dd if=/dev/urandom bs=32 count=1 status=none | xxd -p -c 32`
+- `timeout`: How long should be waited for HTTP responses in sources manager? Defaults to `"30s"`.
 
 ### <a name="section_remote_validator"></a> Section `[remote_validator]` Remote validator
 
@@ -127,10 +128,10 @@ Valid values for `tlps` are the [Traffic Light Protocol](https://en.wikipedia.or
 ### <a name="section_client"></a> Section `[client]` Client configuration
 
 - `keycloak_url`: The URL where the Keycloak server is located. Defaults to same as `keycloak.url`.
-- `keycloak_realm`: The name of the Keycloak realm. Defaults to "isduba".
-- `keycloak_client_id`: The public client identifier. Defaults to "auth".
-- `update_interval`: Specifies how often the token should be renewed. Defaults to "5m".
-- `idle_timeout`: When the user should be logged out after inactivity. Defaults to "30m".
+- `keycloak_realm`: The name of the Keycloak realm. Defaults to `"isduba"`.
+- `keycloak_client_id`: The public client identifier. Defaults to `"auth"`.
+- `update_interval`: Specifies how often the token should be renewed. Defaults to `"5m"`.
+- `idle_timeout`: When the user should be logged out after inactivity. Defaults to `"30m"`.
 
 ## <a name="env_vars"></a>Environment variables
 
@@ -177,6 +178,7 @@ Valid values for `tlps` are the [Traffic Light Protocol](https://en.wikipedia.or
 | `ISDUBA_SOURCES_INSECURE`             | `sources insecure`                   |
 | `ISDUBA_SOURCES_SIGNATURE_CHECK`      | `sources signature_check`            |
 | `ISDUBA_SOURCES_AES_KEY`              | `sources aes_key`                    |
+| `ISDUBA_SOURCES_TIMEOUT`              | `sources timeout`                    |
 | `ISDUBA_REMOTE_VALIDATOR_URL`         | `remote_validator url`               |
 | `ISDUBA_REMOTE_VALIDATOR_CACHE`       | `remote_validator cache`             |
 | `ISDUBA_CLIENT_KEYCLOAK_URL`          | `client keycloak_url`                |

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -88,19 +88,20 @@ const (
 )
 
 const (
-	defaultDownloadSlots        = 100
-	defaultMaxSlotsPerSource    = 2
-	defaultMaxRatePerSlot       = 0
-	defaultOpenPGPCaching       = 24 * time.Hour
-	defaultFeedRefresh          = 15 * time.Minute
-	defaultFeedLogLevel         = InfoFeedLogLevel
-	defaultFeedImporter         = "feedimporter"
-	defaultMessageSourceManager = "Missing something? To suggest new CSAF sources, " +
+	defaultSourcesDownloadSlots     = 100
+	defaultSourcesMaxSlotsPerSource = 2
+	defaultSourcesMaxRatePerSlot    = 0
+	defaultSourcesOpenPGPCaching    = 24 * time.Hour
+	defaultSourcesFeedRefresh       = 15 * time.Minute
+	defaultSourcesTimeout           = 30 * time.Second
+	defaultSourcesFeedLogLevel      = InfoFeedLogLevel
+	defaultSourcesFeedImporter      = "feedimporter"
+	defaultSourcesDefaultMessage    = "Missing something? To suggest new CSAF sources, " +
 		"please contact your CSAF source manager or your administrator."
-	defaultStrictMode     = true
-	defaultInsecure       = false
-	defaultSignatureCheck = true
-	defaultAESKey         = ""
+	defaultSourcesStrictMode     = true
+	defaultSourcesInsecure       = false
+	defaultSourcesSignatureCheck = true
+	defaultSourcesAESKey         = ""
 )
 
 const (
@@ -182,6 +183,7 @@ type Sources struct {
 	MaxRatePerSource  float64               `toml:"max_rate_per_source"`
 	OpenPGPCaching    time.Duration         `toml:"openpgp_caching"`
 	FeedRefresh       time.Duration         `toml:"feed_refresh"`
+	Timeout           time.Duration         `toml:"timeout"`
 	FeedLogLevel      FeedLogLevel          `tomt:"feed_log_level"`
 	PublishersTLPs    models.PublishersTLPs `toml:"publishers_tlps"`
 	FeedImporter      string                `toml:"feed_importer"`
@@ -313,18 +315,18 @@ func Load(file string) (*Config, error) {
 			StorageDuration: defaultTempStorageDuration,
 		},
 		Sources: Sources{
-			DownloadSlots:     defaultDownloadSlots,
-			MaxSlotsPerSource: defaultMaxSlotsPerSource,
-			MaxRatePerSource:  defaultMaxRatePerSlot,
-			OpenPGPCaching:    defaultOpenPGPCaching,
-			FeedRefresh:       defaultFeedRefresh,
-			FeedLogLevel:      defaultFeedLogLevel,
-			FeedImporter:      defaultFeedImporter,
+			DownloadSlots:     defaultSourcesDownloadSlots,
+			MaxSlotsPerSource: defaultSourcesMaxSlotsPerSource,
+			MaxRatePerSource:  defaultSourcesMaxRatePerSlot,
+			OpenPGPCaching:    defaultSourcesOpenPGPCaching,
+			FeedRefresh:       defaultSourcesFeedRefresh,
+			FeedLogLevel:      defaultSourcesFeedLogLevel,
+			FeedImporter:      defaultSourcesFeedImporter,
 			PublishersTLPs:    defaultSourcesPublishersTLPs,
-			DefaultMessage:    defaultMessageSourceManager,
-			StrictMode:        defaultStrictMode,
-			Insecure:          defaultInsecure,
-			SignatureCheck:    defaultSignatureCheck,
+			DefaultMessage:    defaultSourcesDefaultMessage,
+			StrictMode:        defaultSourcesStrictMode,
+			Insecure:          defaultSourcesInsecure,
+			SignatureCheck:    defaultSourcesSignatureCheck,
 		},
 		RemoteValidator: csaf.RemoteValidatorOptions{
 			URL:     defaultRemoteValidatorURL,
@@ -413,6 +415,7 @@ func (cfg *Config) fillFromEnv() error {
 		envStore{"ISDUBA_SOURCES_STRICT_MODE", storeBool(&cfg.Sources.StrictMode)},
 		envStore{"ISDUBA_SOURCES_INSECURE", storeBool(&cfg.Sources.Insecure)},
 		envStore{"ISDUBA_SOURCES_SIGNATURE_CHECK", storeBool(&cfg.Sources.SignatureCheck)},
+		envStore{"ISDUBA_SOURCES_TIMEOUT", storeDuration(&cfg.Sources.Timeout)},
 		envStore{"ISDUBA_SOURCES_AES_KEY", storeString(&cfg.Sources.AESKey)},
 		envStore{"ISDUBA_REMOTE_VALIDATOR_URL", storeString(&cfg.RemoteValidator.URL)},
 		envStore{"ISDUBA_REMOTE_VALIDATOR_CACHE", storeString(&cfg.RemoteValidator.Cache)},

--- a/pkg/sources/keys.go
+++ b/pkg/sources/keys.go
@@ -40,7 +40,7 @@ func (m *Manager) openPGPKeys(source *source) (*crypto.KeyRing, error) {
 		return keys, nil
 	}
 	keys, _ := crypto.NewKeyRing(nil)
-	lpmd := m.pmdCache.pmd(source.url)
+	lpmd := m.pmdCache.pmd(m, source.url)
 	if !lpmd.Valid() {
 		// Try again soon.
 		m.keysCache.SetWithExpiration(source.id, keys, holdingPMDsDuration)

--- a/pkg/sources/manager.go
+++ b/pkg/sources/manager.go
@@ -631,7 +631,7 @@ func (m *Manager) downloadDone(f *feed, id int64) func() {
 
 // PMD returns the provider metadata from the given url.
 func (m *Manager) PMD(url string) *csaf.LoadedProviderMetadata {
-	return m.pmdCache.pmd(url)
+	return m.pmdCache.pmd(m, url)
 }
 
 // SourceUpdater offers a protocol to update a source. Call the UpdateX

--- a/pkg/sources/pmd.go
+++ b/pkg/sources/pmd.go
@@ -33,7 +33,7 @@ func newPMDCache() *pmdCache {
 	}
 }
 
-func (pc *pmdCache) pmd(url string) *csaf.LoadedProviderMetadata {
+func (pc *pmdCache) pmd(m *Manager, url string) *csaf.LoadedProviderMetadata {
 
 	if lpmd, ok := pc.Get(url); ok {
 		return lpmd
@@ -41,10 +41,17 @@ func (pc *pmdCache) pmd(url string) *csaf.LoadedProviderMetadata {
 
 	header := http.Header{}
 	header.Add("User-Agent", UserAgent)
+
+	baseClient := &http.Client{}
+	if m.cfg.Sources.Timeout > 0 {
+		baseClient.Timeout = m.cfg.Sources.Timeout
+	}
+
 	client := util.Client(&util.HeaderClient{
-		Client: &http.Client{},
+		Client: baseClient,
 		Header: header,
 	})
+
 	if slog.Default().Enabled(context.Background(), slog.LevelDebug) {
 		client = &util.LoggingClient{
 			Client: client,

--- a/pkg/sources/sources.go
+++ b/pkg/sources/sources.go
@@ -376,7 +376,7 @@ func (s *source) httpClient(m *Manager) *http.Client {
 	}
 
 	if m.cfg.Sources.Timeout > 0 {
-		client.Timeout = m.cfg.Keycloak.Timeout
+		client.Timeout = m.cfg.Sources.Timeout
 	}
 
 	client.Transport = &http.Transport{
@@ -399,10 +399,11 @@ func (s *source) applyHeaders(req *http.Request) {
 // doRequestDirectly executes an HTTP request with the source specific parameters.
 func (s *source) doRequestDirectly(m *Manager, req *http.Request) (*http.Response, error) {
 	s.applyHeaders(req)
+	client := s.httpClient(m)
 	if limiter := s.wait(); limiter != nil {
 		limiter.Wait(context.Background())
 	}
-	return s.httpClient(m).Do(req)
+	return client.Do(req)
 }
 
 // doRequest executes an HTTP request with the source specific parameters.

--- a/pkg/sources/sources.go
+++ b/pkg/sources/sources.go
@@ -375,6 +375,10 @@ func (s *source) httpClient(m *Manager) *http.Client {
 		tlsConfig.Certificates = s.tlsCertificates
 	}
 
+	if m.cfg.Sources.Timeout > 0 {
+		client.Timeout = m.cfg.Keycloak.Timeout
+	}
+
 	client.Transport = &http.Transport{
 		TLSClientConfig: &tlsConfig,
 	}


### PR DESCRIPTION
This PR adds a configurable timeout (defaults to 30s) to the HTTP request issued by the source manager.