### PR TITLE
Source Manager: Return age in a more readable way

### DIFF
--- a/pkg/web/sources.go
+++ b/pkg/web/sources.go
@@ -81,7 +81,7 @@ func threeStars(b bool) *string {
 }
 
 func (c *Controller) viewSources(ctx *gin.Context) {
-	var srcs []*source
+	srcs := []*source{}
 	c.sm.AllSources(func(
 		id int64,
 		name string,


### PR DESCRIPTION
This PR returns the age field of a source in a none nanosecond way.
```json
[
    {
      "id": 2,
      "name": "Red Hat 3",
      "url": "redhat.com",
      "active": false,
      "headers": [
        "Foo:Bar",
        "Shut:Down"
      ],
      "age": "10m0s",
      "ignore_patterns": [
        "foo"
      ]
    }
  ]

```