### PR TITLE
Source manager: paginate feed logs

### DIFF
--- a/client/src/lib/Sources/SourceEditor.svelte
+++ b/client/src/lib/Sources/SourceEditor.svelte
@@ -305,10 +305,10 @@
 
   const fetchFeedLogs = async (id: number) => {
     loadingLogs = true;
-    const resp = await request(`/api/sources/feeds/${id}/log`, "GET");
+    const resp = await request(`/api/sources/feeds/${id}/log?limit=10`, "GET");
     loadingLogs = false;
     if (resp.ok) {
-      logs = resp.content;
+      logs = resp.content.entries;
     } else if (resp.error) {
       logError = getErrorDetails(`Could not load feed logs`, resp);
     }


### PR DESCRIPTION
This PR introduces pagination to feed logs by the query parameters `limit` and `offset`.
You can filter for certain log levels with the `levels` parameter.
`count` can be used to count the total number of logs for a given filter.