### PR TITLE
Source manager: stats support for sources and feeds

### DIFF
--- a/pkg/sources/manager.go
+++ b/pkg/sources/manager.go
@@ -299,8 +299,8 @@ func (m *Manager) Run(ctx context.Context) {
 	}
 }
 
-// ViewSource returns infos about a source.
-func (m *Manager) ViewSource(id int64, stats bool) *SourceInfo {
+// Source returns infos about a source.
+func (m *Manager) Source(id int64, stats bool) *SourceInfo {
 	siCh := make(chan *SourceInfo)
 	m.fns <- func(m *Manager) {
 		s := m.findSourceByID(id)

--- a/pkg/sources/sources.go
+++ b/pkg/sources/sources.go
@@ -276,6 +276,25 @@ func (f *feed) findWaiting() *location {
 	return nil
 }
 
+func (f *feed) addStats(st *Stats) {
+	for i := range f.queue {
+		switch f.queue[i].state {
+		case waiting:
+			st.Waiting++
+		case running:
+			st.Downloading++
+		}
+	}
+}
+
+func (s *source) addStats(st *Stats) {
+	for _, f := range s.feeds {
+		if !f.invalid.Load() {
+			f.addStats(st)
+		}
+	}
+}
+
 // forceIndexRefresh forces an index refresh on all feeds of a source.
 func (s *source) forceIndexRefresh() {
 	past := time.Now().Add(-time.Minute)

--- a/pkg/sources/sources.go
+++ b/pkg/sources/sources.go
@@ -231,7 +231,7 @@ func (f *feed) removeOlder(db *database.DB, candidates []location) ([]location, 
 
 	// XXX: This could be optimized by passing ranges to Delete.
 	for i := len(remove) - 1; i >= 0; i-- {
-		candidates = slices.Delete(candidates, remove[i], remove[i])
+		candidates = slices.Delete(candidates, remove[i], remove[i]+1)
 	}
 
 	return candidates, nil

--- a/pkg/web/controller.go
+++ b/pkg/web/controller.go
@@ -156,6 +156,7 @@ func (c *Controller) Bind() http.Handler {
 	api.POST("/sources", authSM, c.createSource)
 	api.GET("/sources/message", authAll, c.defaultMessage)
 	api.DELETE("/sources/:id", authSM, c.deleteSource)
+	api.GET("/sources/:id", authSM, c.viewSource)
 	api.PUT("/sources/:id", authSM, c.updateSource)
 
 	// Source feeds

--- a/pkg/web/sources.go
+++ b/pkg/web/sources.go
@@ -247,7 +247,7 @@ func (c *Controller) viewSource(ctx *gin.Context) {
 	if !ok {
 		return
 	}
-	si := c.sm.ViewSource(input.ID, stats)
+	si := c.sm.Source(input.ID, stats)
 	if si == nil {
 		ctx.JSON(http.StatusNotFound, gin.H{"error": "not found"})
 		return


### PR DESCRIPTION
This PR add stats support for feeds and sources.

* There is a new endpoint `GET`  `/api/sources/:id` to fetch only one source.
* `GET` `/api/sources`, `/api/sources/:id`, `/api/sources/:id/feeds` and `/api/sources/feeds/:id` all supports now an optional query parameter `?stats=true` which add stats output to the returned JSON.
* **Important**: This PR also fixes a bug which led to downloading advisories which are already in the database.