### PR TITLE
Improve query designer

### DIFF
--- a/client/src/lib/Queries/QueryDesigner.svelte
+++ b/client/src/lib/Queries/QueryDesigner.svelte
@@ -310,26 +310,29 @@
   <div class="md:w-3/4">
     <div class="flex flex-col">
       <div class="flex flex-row flex-wrap gap-4">
-        <div class="flex w-1/3 min-w-40 flex-col gap-x-2">
-          <Label class={wasNameEdited && currentSearch.name === "" ? "text-red-500" : ""}
-            >Name:</Label
-          >
-          <Input
-            on:input={() => {
-              wasNameEdited = true;
-            }}
-            bind:value={currentSearch.name}
-          />
+        <div class="flex w-1/3 min-w-56 flex-col gap-x-2">
+          <div>
+            <Label class={wasNameEdited && currentSearch.name === "" ? "text-red-500" : ""}
+              >Name:</Label
+            >
+            <Input
+              on:input={() => {
+                wasNameEdited = true;
+              }}
+              bind:value={currentSearch.name}
+            />
+          </div>
+          <div class="mb-2">
+            <small
+              class={wasNameEdited && currentSearch.name === "" ? "text-red-500" : "text-gray-400"}
+              >Required</small
+            >
+          </div>
         </div>
-        <div class="flex w-1/3 min-w-96 flex-col gap-x-2">
+        <div class="mb-4 flex w-1/3 min-w-56 flex-col gap-x-2 md:mb-0 md:min-w-96">
           <Label>Description:</Label>
           <Input bind:value={currentSearch.description} />
         </div>
-      </div>
-      <div class="mb-4">
-        <small class={wasNameEdited && currentSearch.name === "" ? "text-red-500" : "text-gray-400"}
-          >Required</small
-        >
       </div>
     </div>
     <div class="mb-4 flex gap-4">
@@ -389,8 +392,8 @@
     >
     <div class="mt-2">
       <div class="mb-2 flex flex-row">
-        <div class="ml-6 w-1/3 min-w-40">Column</div>
-        <div class="w-1/4 min-w-28">Visible</div>
+        <div class="me-2 ml-6 w-1/3 min-w-40">Column</div>
+        <div class="me-2 w-1/4 md:min-w-28">Visible</div>
         <div class="text-nowrap">Order</div>
       </div>
       <section bind:this={columnList}>
@@ -403,12 +406,12 @@
             on:focus={() => {}}
           >
             <div class:w-6={true} class:flex={true} class:flex-col={true}>
-              <button class="h-4">
-                <Img src="grid-dots-vertical-rounded.svg" class="h-4 min-h-2 min-w-2 invert-[.5]" />
+              <button>
+                <Img src="grid-dots-vertical-rounded.svg" class="h-auto w-5 invert-[.5]" />
               </button>
             </div>
-            <div class="columnName w-1/3 min-w-40">{col.name}</div>
-            <div class="w-1/4 min-w-28">
+            <div class="columnName me-2 w-1/3 min-w-40">{col.name}</div>
+            <div class="me-2 w-1/4 md:min-w-28">
               <Checkbox
                 on:change={() => {
                   setVisible(index);
@@ -437,12 +440,17 @@
         {/each}
       </section>
     </div>
-    <div class="mt-6 w-full min-w-96">
+    <div class="mt-6 w-full">
       <h5 class="text-lg font-medium text-gray-500 dark:text-gray-400">Query criteria</h5>
       <div class="flex flex-row">
         <Input bind:value={currentSearch.query} />
       </div>
-      <div class="mt-3 flex flex-row">
+      {#if saveErrorMessage}
+        <div class="mt-2 flex md:justify-end">
+          <ErrorMessage error={saveErrorMessage}></ErrorMessage>
+        </div>
+      {/if}
+      <div class="mt-3 flex flex-row flex-wrap">
         {#if loading}
           <div class="loadingFadeIn mr-4 mt-3">
             Loading ...
@@ -457,7 +465,7 @@
         {#if errorMessage}
           <span class="text-red-600">{errorMessage}</span>
         {/if}
-        <div class="my-2 ml-auto flex flex-row gap-3">
+        <div class="my-2 ml-auto flex flex-row flex-wrap gap-3">
           {#if !loading}
             <Button on:click={testQuery} color="light"
               ><i class="bx bx-test-tube me-2"></i> Test query</Button
@@ -489,9 +497,6 @@
           >
         </div>
       </div>
-      {#if saveErrorMessage}
-        <ErrorMessage error={saveErrorMessage}></ErrorMessage>
-      {/if}
     </div>
   </div>
 {:else}

--- a/client/src/lib/Queries/QueryDesigner.svelte
+++ b/client/src/lib/Queries/QueryDesigner.svelte
@@ -42,8 +42,7 @@
   import Sortable from "sortablejs";
 
   export let params: any = null;
-  let editName = false;
-  let editDescription = false;
+  let wasNameEdited = false;
   let queryCount: any = null;
   let loading = false;
   let errorMessage: ErrorDetails | null;
@@ -51,7 +50,6 @@
   let loadQueryError: ErrorDetails | null;
   let loadedData: any = null;
   let abortController: AbortController;
-  let placeholder = "";
 
   let columnList: any;
 
@@ -105,7 +103,7 @@
       searchType: SEARCHTYPES.ADVISORY,
       columns: columns,
       orderBy: [],
-      name: "New Query",
+      name: "",
       query: "",
       description: "",
       global: false,
@@ -203,12 +201,6 @@
     }
   };
 
-  const shorten = (text: string) => {
-    if (!text) return "";
-    if (text.length < 20) return text;
-    return `${text.substring(0, 20)}...`;
-  };
-
   const generateQueryFrom = (result: any): Search => {
     let searchType = SEARCHTYPES.DOCUMENT;
     let columns = [];
@@ -266,6 +258,7 @@
     let id;
     if (queryString?.clone) {
       id = queryString?.clone;
+      wasNameEdited = true;
     }
     if (params) id = params.id;
     if (id) {
@@ -316,73 +309,27 @@
 {#if loadQueryError !== null}
   <div class="md:w-3/4">
     <div class="flex flex-col">
-      <div class="flex flex-row">
-        <div class="flex w-1/3 min-w-40 flex-row items-center gap-x-2">
-          <span class={currentSearch.name === "" ? "text-red-500" : ""}>Name:</span>
-          <button
-            on:click={() => {
-              editName = !editName;
-            }}
+      <div class="flex flex-row flex-wrap gap-4">
+        <div class="flex w-1/3 min-w-40 flex-col gap-x-2">
+          <Label class={wasNameEdited && currentSearch.name === "" ? "text-red-500" : ""}
+            >Name:</Label
           >
-            {#if editName}
-              <Input
-                autofocus
-                {placeholder}
-                bind:value={currentSearch.name}
-                on:keyup={(e) => {
-                  if (e.key === "Enter") editName = false;
-                  if (e.key === "Escape") editName = false;
-                  e.preventDefault();
-                }}
-                on:blur={() => {
-                  editName = false;
-                }}
-                on:click={(e) => e.stopPropagation()}
-              />
-            {:else}
-              <div class="flex flex-row items-center" title={currentSearch.name}>
-                <h5 class="font-medium text-gray-500 dark:text-gray-400">
-                  {shorten(currentSearch.name)}
-                </h5>
-                <i class="bx bx-edit-alt ml-1"></i>
-              </div>
-            {/if}
-          </button>
+          <Input
+            on:input={() => {
+              wasNameEdited = true;
+            }}
+            bind:value={currentSearch.name}
+          />
         </div>
-        <div class="ml-6 flex w-1/3 min-w-96 flex-row items-center gap-x-2">
-          <span>Description:</span>
-          <button
-            on:click={() => {
-              editDescription = !editDescription;
-            }}
-          >
-            {#if editDescription}
-              <Input
-                autofocus
-                bind:value={currentSearch.description}
-                on:keyup={(e) => {
-                  if (e.key === "Enter") editDescription = false;
-                  if (e.key === "Escape") editDescription = false;
-                  e.preventDefault();
-                }}
-                on:blur={() => {
-                  editDescription = false;
-                }}
-                on:click={(e) => e.stopPropagation()}
-              />
-            {:else}
-              <div class="flex flex-row items-center" title={currentSearch.description}>
-                <h5 class="font-medium text-gray-500 dark:text-gray-400">
-                  {shorten(currentSearch.description)}
-                </h5>
-                <i class="bx bx-edit-alt ml-1"></i>
-              </div>
-            {/if}
-          </button>
+        <div class="flex w-1/3 min-w-96 flex-col gap-x-2">
+          <Label>Description:</Label>
+          <Input bind:value={currentSearch.description} />
         </div>
       </div>
       <div class="mb-4">
-        <small class={currentSearch.name === "" ? "text-red-500" : "text-gray-400"}>Required</small>
+        <small class={wasNameEdited && currentSearch.name === "" ? "text-red-500" : "text-gray-400"}
+          >Required</small
+        >
       </div>
     </div>
     <div class="mb-4 flex gap-4">

--- a/client/src/lib/Queries/QueryDesigner.svelte
+++ b/client/src/lib/Queries/QueryDesigner.svelte
@@ -314,7 +314,7 @@
 <hr class="mb-6" />
 
 {#if loadQueryError !== null}
-  <div class="w-3/4">
+  <div class="md:w-3/4">
     <div class="flex flex-col">
       <div class="flex flex-row">
         <div class="flex w-1/3 min-w-40 flex-row items-center gap-x-2">
@@ -413,14 +413,8 @@
         <Select id="roles" items={roles} bind:value={currentSearch.role}></Select>
       {/if}
     </div>
-    <div class="flex flex-row">
-      <div class="flex w-1/3 min-w-40 -flex-row items-baseline gap-x-3">
-        <h5 class="text-lg font-medium text-gray-500 dark:text-gray-400">Searching</h5>
-        <small class:text-red-500={noColumnSelected} class:text-gray-400={!noColumnSelected}
-          >Select at least 1 column</small
-        >
-      </div>
-      <ButtonGroup class="ml-6">
+    <div class="mb-2">
+      <ButtonGroup>
         <RadioButton
           class="h-8"
           on:change={toggleSearchType}
@@ -443,7 +437,10 @@
         >
       </ButtonGroup>
     </div>
-    <div class="mt-4">
+    <small class:text-red-500={noColumnSelected} class:text-gray-400={!noColumnSelected}
+      >Select at least 1 column</small
+    >
+    <div class="mt-2">
       <div class="mb-2 flex flex-row">
         <div class="ml-6 w-1/3 min-w-40">Column</div>
         <div class="w-1/4 min-w-28">Visible</div>


### PR DESCRIPTION
Overall, should be working much better on smaller screens. Also, we use input fields for name and description of queries instead of a combination of input field *and* label. The combination lead to jumps of the elements when switching between display and edit mode and it makes code maintenance more complicated than necessary. The last improvement is that the error message when save failed is shown above the buttons so you don't have to scroll down to see it.