### PR TITLE
Dashboard (config)

### DIFF
--- a/client/src/lib/Dashboard/AdvisoryQuery.svelte
+++ b/client/src/lib/Dashboard/AdvisoryQuery.svelte
@@ -92,18 +92,9 @@
             <Activity on:click={() => openDocument(doc)}>
               <div slot="top-left">
                 {#if doc.critical}
-                  <div>
-                    {#if doc.cvss_v3_score && doc.cvss_v3_score === doc.critical}
-                      <span>CVSS v3:</span>
-                    {:else if doc.cvss_v2_score && doc.cvss_v2_score === doc.critical}
-                      <span>CVSS v2:</span>
-                    {:else}
-                      <span>Critical:</span>
-                    {/if}
-                    <span class:text-red-500={Number(doc.critical) > 5.0}>
-                      {doc.critical}
-                    </span>
-                  </div>
+                  <span class:text-red-500={Number(doc.critical) > 5.0}>
+                    {doc.critical}
+                  </span>
                 {/if}
               </div>
               <span slot="top-right" class="ml-auto">{getPublisher(doc.publisher)}</span>

--- a/client/src/lib/Dashboard/AdvisoryQuery.svelte
+++ b/client/src/lib/Dashboard/AdvisoryQuery.svelte
@@ -18,13 +18,14 @@
   import ErrorMessage from "$lib/Errors/ErrorMessage.svelte";
   import Activity from "./Activity.svelte";
   import { getPublisher } from "$lib/publisher";
-  import { Button } from "flowbite-svelte";
+  import { Button, Spinner } from "flowbite-svelte";
   import { getRelativeTime } from "./activity";
   import SsvcBadge from "$lib/Advisories/SSVC/SSVCBadge.svelte";
 
   export let storedQuery: any;
-  let documents: any[] = [];
+  let documents: any[] | null = null;
   let newDocumentsError: ErrorDetails | null;
+  let isLoading = false;
   const ignoredColumns = [
     "id",
     "title",
@@ -70,7 +71,9 @@
   };
 
   onMount(async () => {
+    isLoading = true;
     await loadDocuments();
+    isLoading = false;
   });
 
   const openDocument = (doc: any) => {
@@ -86,6 +89,12 @@
   <div class="flex flex-col gap-4 md:w-[46%] md:max-w-[46%]">
     <SectionHeader title={storedQuery.description}></SectionHeader>
     <div class="grid grid-cols-[repeat(auto-fit,_minmax(200pt,_1fr))] gap-6">
+      {#if isLoading}
+        <div class:invisible={!isLoading} class={isLoading ? "loadingFadeIn" : ""}>
+          Loading ...
+          <Spinner color="gray" size="4"></Spinner>
+        </div>
+      {/if}
       {#if documents}
         {#if documents.length > 0}
           {#each documents as doc}

--- a/client/src/lib/Dashboard/AdvisoryQuery.svelte
+++ b/client/src/lib/Dashboard/AdvisoryQuery.svelte
@@ -106,24 +106,18 @@
                   </div>
                 {/if}
               </div>
-              <span slot="top-right" class="ml-auto" title={doc.publisher}
-                >{getPublisher(doc.publisher)}</span
-              >
-              <div class="text-black" title="Title">{doc.title ?? "Title: undefined"}</div>
-              <div class="text-sm text-gray-700" title="Tracking ID">{doc.tracking_id}</div>
-              <div
-                slot="bottom-left"
-                title={`Number of comments`}
-                class="flex items-center gap-4 text-gray-500"
-              >
+              <span slot="top-right" class="ml-auto">{getPublisher(doc.publisher)}</span>
+              <div class="text-black">{doc.title ?? "Title: undefined"}</div>
+              <div class="text-sm text-gray-700">{doc.tracking_id}</div>
+              <div slot="bottom-left" class="flex items-center gap-4 text-gray-500">
                 {#if doc.comments !== undefined}
-                  <div class="flex items-center gap-1" title="Comments">
+                  <div class="flex items-center gap-1">
                     <i class="bx bx-comment"></i>
                     <span>{doc.comments}</span>
                   </div>
                 {/if}
                 {#if doc.versions !== undefined}
-                  <div class="flex items-center gap-1" title="Versions">
+                  <div class="flex items-center gap-1">
                     <i class="bx bx-collection"></i>
                     <span>{doc.versions}</span>
                   </div>
@@ -134,9 +128,7 @@
               </div>
               <div slot="bottom-right" class="text-gray-500">
                 {#if doc.recent !== undefined}
-                  <span title={`Last change: ${doc.recent}`}
-                    >{getRelativeTime(new Date(doc.recent))}</span
-                  >
+                  <span>{getRelativeTime(new Date(doc.recent))}</span>
                 {/if}
               </div>
               <div slot="bottom-bottom">

--- a/client/src/lib/Dashboard/Dashboard.svelte
+++ b/client/src/lib/Dashboard/Dashboard.svelte
@@ -60,6 +60,7 @@
       (query) =>
         query.dashboard &&
         query.global &&
+        query.definer === "system-default" &&
         !userDashboardQueries.find((q) => q.id === query.id) &&
         (!ignoredQueries || !ignoredQueries.includes(query.id))
     );

--- a/client/src/lib/Dashboard/Dashboard.svelte
+++ b/client/src/lib/Dashboard/Dashboard.svelte
@@ -20,11 +20,6 @@
 
   let filteredQueries: any[] = [];
   let loadIgnoredError: ErrorDetails | null;
-
-  $: advisoryQueries = filteredQueries.filter((query: any) =>
-    [SEARCHTYPES.ADVISORY, SEARCHTYPES.DOCUMENT].includes(query.kind)
-  );
-  $: eventQueries = filteredQueries.filter((query: any) => query.kind === SEARCHTYPES.EVENT);
   let loadQueryError: ErrorDetails | null;
 
   const fetchStoredQueries = async (): Promise<any[]> => {
@@ -77,12 +72,13 @@
 </svelte:head>
 
 {#if $appStore.app.isUserLoggedIn}
-  <div class="mb-8 mt-8 flex flex-wrap gap-10">
-    {#each advisoryQueries as query}
-      <AdvisoryQuery storedQuery={query}></AdvisoryQuery>
-    {/each}
-    {#each eventQueries as query}
-      <EventQuery storedQuery={query}></EventQuery>
+  <div class="mb-8 mt-8 flex flex-row flex-wrap gap-10">
+    {#each filteredQueries as query}
+      {#if [SEARCHTYPES.ADVISORY, SEARCHTYPES.DOCUMENT].includes(query.kind)}
+        <AdvisoryQuery storedQuery={query}></AdvisoryQuery>
+      {:else}
+        <EventQuery storedQuery={query}></EventQuery>
+      {/if}
     {/each}
   </div>
   <ErrorMessage error={loadQueryError}></ErrorMessage>

--- a/client/src/lib/Dashboard/Dashboard.svelte
+++ b/client/src/lib/Dashboard/Dashboard.svelte
@@ -65,11 +65,10 @@
       (query) =>
         query.dashboard &&
         query.global &&
-        (appStore.getRoles().includes(query.role) || !query.role) &&
         !userDashboardQueries.find((q) => q.id === query.id) &&
         (!ignoredQueries || !ignoredQueries.includes(query.id))
     );
-    filteredQueries = [...userDashboardQueries, ...globalDashboardQueries];
+    filteredQueries = [...userDashboardQueries, ...globalDashboardQueries.slice(0, 2)];
   });
 </script>
 

--- a/client/src/lib/Dashboard/Dashboard.svelte
+++ b/client/src/lib/Dashboard/Dashboard.svelte
@@ -61,7 +61,6 @@
         query.dashboard &&
         query.global &&
         query.definer === "system-default" &&
-        !userDashboardQueries.find((q) => q.id === query.id) &&
         (!ignoredQueries || !ignoredQueries.includes(query.id))
     );
     filteredQueries = [...userDashboardQueries, ...globalDashboardQueries.slice(0, 2)];

--- a/client/src/lib/Dashboard/EventQuery.svelte
+++ b/client/src/lib/Dashboard/EventQuery.svelte
@@ -237,9 +237,7 @@
               }}
             >
               <div slot="top-right">
-                <span title={`Time of event: ${activity.time}`}
-                  >{getRelativeTime(new Date(activity.time))}</span
-                >
+                <span>{getRelativeTime(new Date(activity.time))}</span>
               </div>
               <span slot="top-left">
                 {#if activity.mention}
@@ -255,7 +253,7 @@
                 {:else if activity.event === "change_comment"}
                   {activity.actor} changed a comment
                 {:else if activity.event === "state_change"}
-                  {activity.actor} changed the state to <Badge color="dark" title="Workflow state"
+                  {activity.actor} changed the state to <Badge color="dark"
                     >{activity.event_state}</Badge
                   >
                 {/if}
@@ -269,10 +267,10 @@
                   >
                 </div>
               {:else}
-                <div title="Title">
+                <div>
                   {activity.documentTitle ?? "Title undefined"}
                 </div>
-                <div class="text-sm text-gray-700" title="Tracking ID">
+                <div class="text-sm text-gray-700">
                   {activity.tracking_id ?? "Trackind ID undefined"}
                 </div>
               {/if}
@@ -284,13 +282,13 @@
               <div slot="bottom-bottom">
                 <div class="flex items-center gap-4 text-xs text-gray-500">
                   {#if activity.comments !== undefined}
-                    <div class="flex items-center gap-1" title="Comments">
+                    <div class="flex items-center gap-1">
                       <i class="bx bx-comment"></i>
                       <span>{activity.comments}</span>
                     </div>
                   {/if}
                   {#if activity.versions !== undefined}
-                    <div class="flex items-center gap-1" title="Versions">
+                    <div class="flex items-center gap-1">
                       <i class="bx bx-collection"></i>
                       <span>{activity.versions}</span>
                     </div>

--- a/client/src/lib/Dashboard/EventQuery.svelte
+++ b/client/src/lib/Dashboard/EventQuery.svelte
@@ -16,7 +16,7 @@
   import { request } from "$lib/request";
   import { getErrorDetails, type ErrorDetails } from "$lib/Errors/error";
   import Activity from "./Activity.svelte";
-  import { Badge, Button } from "flowbite-svelte";
+  import { Badge, Button, Spinner } from "flowbite-svelte";
   import { push } from "svelte-spa-router";
   import { convertVectorToSSVCObject } from "$lib/Advisories/SSVC/SSVCCalculator";
   import { getRelativeTime } from "./activity";
@@ -47,6 +47,7 @@
   let loadActivityError: ErrorDetails | null;
   let loadCommentsError: ErrorDetails | null;
   let loadDocumentsError: ErrorDetails | null;
+  let isLoading = false;
 
   const aggregateNewest = (events: any) => {
     return events.reduce((o: any, n: any) => {
@@ -130,7 +131,9 @@
   };
 
   onMount(async () => {
-    transformDataToActivities();
+    isLoading = true;
+    await transformDataToActivities();
+    isLoading = false;
   });
 
   const showMore = () => {
@@ -142,6 +145,12 @@
   <div class="flex flex-col gap-4 md:w-[46%] md:max-w-[46%]">
     <SectionHeader title={storedQuery.description}></SectionHeader>
     <div class="grid grid-cols-[repeat(auto-fit,_minmax(200pt,_1fr))] gap-6">
+      {#if isLoading}
+        <div class:invisible={!isLoading} class={isLoading ? "loadingFadeIn" : ""}>
+          Loading ...
+          <Spinner color="gray" size="4"></Spinner>
+        </div>
+      {/if}
       {#if resultingActivities}
         {#if resultingActivities.length > 0}
           {#each resultingActivities as activity}
@@ -193,7 +202,7 @@
                   ? `${activity.title ?? "Title undefined"}`
                   : ""}
               </span>
-              <div slot="bottom-bottom">
+              <div slot="bottom-bottom" class="mt-2">
                 <div class="flex items-center gap-4 text-xs text-gray-500">
                   {#if activity.comments !== undefined}
                     <div class="flex items-center gap-1">

--- a/client/src/lib/Dashboard/EventQuery.svelte
+++ b/client/src/lib/Dashboard/EventQuery.svelte
@@ -183,10 +183,8 @@
               </span>
               {#if activity.event === "add_comment" || activity.event == "change_comment"}
                 <div>
-                  <span class="italic"
-                    >{activity.message && activity.message?.length < 30
-                      ? activity.message
-                      : (activity.message?.substring(0, 30) ?? "Message undefined")}</span
+                  <span class="block overflow-hidden text-ellipsis text-nowrap italic"
+                    >{activity.message ?? "Message undefined"}</span
                   >
                 </div>
               {:else}

--- a/client/src/lib/Queries/Overview.svelte
+++ b/client/src/lib/Queries/Overview.svelte
@@ -146,6 +146,7 @@
     cloneErrorMessage = null;
     const idsOfClonesQueries = [];
     let failed = false;
+    // Clone the special queries
     for (let i = 0; i < firstTwoQueries.length; i++) {
       const queryToClone = firstTwoQueries[i];
       if (queryToClone) {
@@ -161,6 +162,17 @@
       }
     }
     if (!failed) {
+      // Hide the special queries as they are now replaced
+      for (let i = 0; i < firstTwoQueries.length; i++) {
+        if (!ignoredQueries.includes(firstTwoQueries[i].id)) {
+          ({ ignoredQueries, errorMessage = cloneErrorMessage } = await setIgnored(
+            firstTwoQueries[i].id,
+            true,
+            ignoredQueries
+          ));
+        }
+      }
+      // Place the cloned queries at the top
       type Order = {
         id: number;
         order: number;

--- a/client/src/lib/Queries/Overview.svelte
+++ b/client/src/lib/Queries/Overview.svelte
@@ -430,7 +430,7 @@
                   ></CCheckbox>
                 </TableBodyCell>
                 <td>
-                  {#if !firstTwoQueries.find((q) => q.id === query.id || appStore.isAdmin())}
+                  {#if !firstTwoQueries.find((q) => q.id === query.id) || appStore.isAdmin()}
                     <CIconButton
                       title={`clone ${query.name}`}
                       icon="copy"

--- a/client/src/lib/Queries/Overview.svelte
+++ b/client/src/lib/Queries/Overview.svelte
@@ -349,7 +349,8 @@
         <span class="text-2xl">Global</span>
         {#if !appStore.isAdmin()}
           <Button class="h-fit p-1 text-xs" on:click={cloneDashboardQueries} color="light"
-            >Clone global queries for my role</Button
+            >Clone global dashboard queries for my role and hide cloned queries (<span>*</span
+            >)</Button
           >
         {/if}
       </div>
@@ -400,7 +401,11 @@
                   {/if}
                 </TableBodyCell>
                 <TableBodyCell {tdClass}>
-                  <span>{query.name ?? "-"}</span>
+                  <span>{query.name ?? "-"}</span><span
+                    >{!appStore.isAdmin() && firstTwoQueries.find((q) => q.id === query.id)
+                      ? "*"
+                      : ""}</span
+                  >
                 </TableBodyCell>
                 <TableBodyCell {tdClass}>{query.description ?? "-"}</TableBodyCell>
                 <TableBodyCell {tdClass}>

--- a/client/src/lib/Queries/Overview.svelte
+++ b/client/src/lib/Queries/Overview.svelte
@@ -30,6 +30,7 @@
   let cloneErrorMessage: ErrorDetails | null;
   let querytoDelete: any = resetQueryToDelete();
   let loading = false;
+  let isCloning = false;
 
   $: globalRelevantQueries = queries
     ?.filter((q) => q.definer === "system-default" && q.global && q.dashboard)
@@ -94,6 +95,7 @@
     cloneErrorMessage = null;
     const idsOfClonesQueries = [];
     let failed = false;
+    isCloning = true;
     // Clone the special queries
     for (let i = 0; i < globalRelevantQueries.length; i++) {
       const queryToClone = globalRelevantQueries[i];
@@ -143,6 +145,7 @@
         cloneErrorMessage = getErrorDetails(`Could not update query order.`, response);
       }
     }
+    isCloning = false;
     fetchData();
   };
 </script>
@@ -200,7 +203,10 @@
         <ErrorMessage error={cloneErrorMessage}></ErrorMessage>
         <Button class="h-fit w-fit text-sm" on:click={cloneDashboardQueries}>
           <i class="bx bx-copy me-2"></i>
-          <span>Clone relevant queries and hide cloned queries</span>
+          <span class="me-2">Clone relevant queries and hide cloned queries</span>
+          <div class:invisible={!isCloning} class={isCloning ? "loadingFadeIn text-white" : ""}>
+            <Spinner color="white" size="4"></Spinner>
+          </div>
         </Button>
       </QueryTable>
 

--- a/client/src/lib/Queries/Overview.svelte
+++ b/client/src/lib/Queries/Overview.svelte
@@ -154,7 +154,14 @@
   <title>User defined queries</title>
 </svelte:head>
 
-<Modal size="xs" title={querytoDelete.name} bind:open={deleteModalOpen} autoclose outsideclose>
+<Modal
+  size="xs"
+  title={querytoDelete.name}
+  bind:open={deleteModalOpen}
+  autoclose
+  outsideclose
+  classHeader="flex justify-between items-center p-4 md:p-5 rounded-t-lg break-all"
+>
   <div class="text-center">
     <h3 class="mb-5 text-lg font-normal text-gray-500 dark:text-gray-400">
       Are you sure you want to delete this query?

--- a/client/src/lib/Queries/Overview.svelte
+++ b/client/src/lib/Queries/Overview.svelte
@@ -208,7 +208,7 @@
         on:openDeleteModal={onOpenDeleteModal}
       >
         <ErrorMessage error={cloneErrorMessage}></ErrorMessage>
-        <Button class="h-fit w-fit text-sm" on:click={cloneDashboardQueries}>
+        <Button class="h-fit w-fit text-sm" on:click={cloneDashboardQueries} disabled={isCloning}>
           <i class="bx bx-copy me-2"></i>
           <span class="me-2">Clone relevant queries and hide cloned queries</span>
           <div class:invisible={!isCloning} class={isCloning ? "loadingFadeIn text-white" : ""}>

--- a/client/src/lib/Queries/Overview.svelte
+++ b/client/src/lib/Queries/Overview.svelte
@@ -86,6 +86,10 @@
     ({ ignoredQueries, errorMessage } = await fetchIgnored());
   };
 
+  const updateIgnored = (event: any) => {
+    ignoredQueries = event.detail;
+  };
+
   onMount(() => {
     fetchData();
   });
@@ -117,8 +121,7 @@
         if (!ignoredQueries.includes(globalRelevantQueries[i].id)) {
           ({ ignoredQueries, errorMessage = cloneErrorMessage } = await setIgnored(
             globalRelevantQueries[i].id,
-            true,
-            ignoredQueries
+            true
           ));
         }
       }
@@ -190,7 +193,7 @@
       isAllowedToEdit={true}
       queries={userQueries}
       title="Personal"
-      on:fetchData={fetchData}
+      on:updateIgnored={updateIgnored}
       on:openDeleteModal={onOpenDeleteModal}
     >
       <Button class="mb-2 mt-3 w-fit" href="/#/queries/new"
@@ -204,7 +207,7 @@
         isAllowedToClone={false}
         queries={globalRelevantQueries}
         title="Global relevant dashboard queries"
-        on:fetchData={fetchData}
+        on:updateIgnored={updateIgnored}
         on:openDeleteModal={onOpenDeleteModal}
       >
         <ErrorMessage error={cloneErrorMessage}></ErrorMessage>
@@ -221,7 +224,7 @@
         {ignoredQueries}
         queries={globalDashboardQueries}
         title="Global dashboard queries (not displayed)"
-        on:fetchData={fetchData}
+        on:updateIgnored={updateIgnored}
         on:openDeleteModal={onOpenDeleteModal}
       ></QueryTable>
 
@@ -229,7 +232,7 @@
         {ignoredQueries}
         queries={globalSearchQueries}
         title="Global search queries"
-        on:fetchData={fetchData}
+        on:updateIgnored={updateIgnored}
         on:openDeleteModal={onOpenDeleteModal}
       ></QueryTable>
     {:else}
@@ -238,7 +241,7 @@
         queries={adminQueries}
         title="Global"
         isAllowedToEdit={appStore.isAdmin()}
-        on:fetchData={fetchData}
+        on:updateIgnored={updateIgnored}
         on:openDeleteModal={onOpenDeleteModal}
       >
         <Button class="mb-2 mt-3 w-fit" href="/#/queries/new"

--- a/client/src/lib/Queries/Overview.svelte
+++ b/client/src/lib/Queries/Overview.svelte
@@ -31,11 +31,13 @@
   let querytoDelete: any = resetQueryToDelete();
   let loading = false;
 
-  $: globalDashboardQueries = queries?.filter((q) => q.dashboard && q.global);
-  $: globalSearchQueries = queries?.filter((q) => !q.dashboard && q.global);
-  $: globalRelevantQueries = globalDashboardQueries
-    ?.filter((q) => q.definer === "system-default")
+  $: globalRelevantQueries = queries
+    ?.filter((q) => q.definer === "system-default" && q.global && q.dashboard)
     .slice(0, 2);
+  $: globalDashboardQueries = queries?.filter(
+    (q) => q.dashboard && q.global && !globalRelevantQueries?.map((q) => q.id).includes(q.id)
+  );
+  $: globalSearchQueries = queries?.filter((q) => !q.dashboard && q.global);
   $: userQueries = queries?.filter((q: Query) => {
     return !q.global;
   });
@@ -174,6 +176,7 @@
 {#if queries && queries.length > 0}
   <div class="flex flex-row flex-wrap gap-12">
     <QueryTable
+      {ignoredQueries}
       isAllowedToEdit={true}
       queries={userQueries}
       title="Personal"
@@ -187,6 +190,7 @@
 
     {#if !appStore.isAdmin()}
       <QueryTable
+        {ignoredQueries}
         isAllowedToClone={false}
         queries={globalRelevantQueries}
         title="Global relevant dashboard queries"
@@ -201,6 +205,7 @@
       </QueryTable>
 
       <QueryTable
+        {ignoredQueries}
         queries={globalDashboardQueries}
         title="Global dashboard queries (not displayed)"
         on:fetchData={fetchData}
@@ -208,6 +213,7 @@
       ></QueryTable>
 
       <QueryTable
+        {ignoredQueries}
         queries={globalSearchQueries}
         title="Global search queries"
         on:fetchData={fetchData}
@@ -215,6 +221,7 @@
       ></QueryTable>
     {:else}
       <QueryTable
+        {ignoredQueries}
         queries={adminQueries}
         title="Global"
         isAllowedToEdit={appStore.isAdmin()}

--- a/client/src/lib/Queries/Overview.svelte
+++ b/client/src/lib/Queries/Overview.svelte
@@ -9,48 +9,39 @@
 -->
 
 <script lang="ts">
-  import { tablePadding, tdClass } from "$lib/Table/defaults";
-  import { Button, Table, TableHead, TableHeadCell, TableBodyCell, Spinner } from "flowbite-svelte";
-  import CCheckbox from "$lib/Components/CCheckbox.svelte";
+  import { Button, Spinner } from "flowbite-svelte";
   import { onMount } from "svelte";
   import { request } from "$lib/request";
   import ErrorMessage from "$lib/Errors/ErrorMessage.svelte";
   import { getErrorDetails, type ErrorDetails } from "$lib/Errors/error";
-  import { push } from "svelte-spa-router";
-  import { Modal, Img } from "flowbite-svelte";
-  import { ADMIN } from "$lib/workflow";
-  import { isRoleIncluded } from "$lib/permissions";
+  import { Modal } from "flowbite-svelte";
   import { appStore } from "$lib/store";
-  import Sortable from "sortablejs";
-  import {
-    fetchIgnored,
-    setIgnored,
-    createStoredQuery,
-    proposeName,
-    updateStoredQuery,
-    type Query
-  } from "./query";
-  import CIconButton from "$lib/Components/CIconButton.svelte";
+  import { fetchIgnored, setIgnored, createStoredQuery, proposeName, type Query } from "./query";
+  import QueryTable from "./QueryTable.svelte";
   let deleteModalOpen = false;
 
   const resetQueryToDelete = () => {
     return { name: "", id: -1 };
   };
 
-  let queries: Query[] = [];
+  let queries: Query[] | undefined = [];
   let ignoredQueries: number[] = [];
-  let orderBy = "";
   let errorMessage: ErrorDetails | null;
-  let ignorePersonalErrorMessage: ErrorDetails | null;
-  let ignoreGlobalErrorMessage: ErrorDetails | null;
   let cloneErrorMessage: ErrorDetails | null;
   let querytoDelete: any = resetQueryToDelete();
   let loading = false;
-  let columnList: any;
-  let columnListAdmin: any;
 
-  $: globalDashboardQueries = queries.filter((q) => q.dashboard && q.global);
-  $: firstTwoQueries = globalDashboardQueries.slice(0, 2);
+  $: globalDashboardQueries = queries?.filter((q) => q.dashboard && q.global);
+  $: globalSearchQueries = queries?.filter((q) => !q.dashboard && q.global);
+  $: globalRelevantQueries = globalDashboardQueries
+    ?.filter((q) => q.definer === "system-default")
+    .slice(0, 2);
+  $: userQueries = queries?.filter((q: Query) => {
+    return !q.global;
+  });
+  $: adminQueries = queries?.filter((q: Query) => {
+    return q.global;
+  });
 
   const fetchQueries = async () => {
     loading = true;
@@ -66,21 +57,9 @@
     loading = false;
   };
 
-  const changeIgnored = async (id: number, isChecked: boolean) => {
-    unsetErrors();
-    ({ ignoredQueries, errorMessage } = await setIgnored(id, isChecked, ignoredQueries));
-  };
-
-  const changeDashboard = async (id: number, isChecked: boolean) => {
-    unsetErrors();
-    const queryToUpdate = queries.filter((q) => q.id === id)[0];
-    if (queryToUpdate) {
-      queryToUpdate.dashboard = isChecked;
-      const response = await updateStoredQuery(queryToUpdate);
-      if (!response.ok && response.error) {
-        ignorePersonalErrorMessage = getErrorDetails(`Could not change option.`, response);
-      }
-    }
+  const onOpenDeleteModal = async (event: any) => {
+    querytoDelete = event.detail;
+    deleteModalOpen = true;
   };
 
   const deleteQuery = async () => {
@@ -94,35 +73,7 @@
     fetchData();
   };
 
-  const updateQueryOrder = async (queries: Query[]) => {
-    let nodes = columnList.querySelectorAll(".columnName");
-    type Order = {
-      id: number;
-      order: number;
-    };
-    let orders: Order[] = [];
-    let i = 0;
-    for (const node of nodes) {
-      let columnName = node.innerText;
-      let query = queries.find((q) => q.name === columnName);
-      if (query) {
-        orders.push({ id: query.id, order: i });
-      }
-      i++;
-    }
-
-    let response = await request(`/api/queries/orders`, "POST", JSON.stringify(orders));
-    if (!response.ok && response.error) {
-      errorMessage = getErrorDetails(`Could not update query order.`, response);
-    }
-    if (response.ok) {
-      push(`/queries/`);
-    }
-  };
-
   const unsetErrors = () => {
-    ignoreGlobalErrorMessage = null;
-    ignorePersonalErrorMessage = null;
     errorMessage = null;
     cloneErrorMessage = null;
   };
@@ -135,20 +86,15 @@
   onMount(() => {
     fetchData();
   });
-  $: userQueries = queries.filter((q: Query) => {
-    return !q.global;
-  });
-  $: adminQueries = queries.filter((q: Query) => {
-    return q.global;
-  });
 
   const cloneDashboardQueries = async () => {
+    if (!globalRelevantQueries || !userQueries || !queries) return;
     cloneErrorMessage = null;
     const idsOfClonesQueries = [];
     let failed = false;
     // Clone the special queries
-    for (let i = 0; i < firstTwoQueries.length; i++) {
-      const queryToClone = firstTwoQueries[i];
+    for (let i = 0; i < globalRelevantQueries.length; i++) {
+      const queryToClone = globalRelevantQueries[i];
       if (queryToClone) {
         queryToClone.global = false;
         queryToClone.name = proposeName(queries, queryToClone.name);
@@ -163,10 +109,10 @@
     }
     if (!failed) {
       // Hide the special queries as they are now replaced
-      for (let i = 0; i < firstTwoQueries.length; i++) {
-        if (!ignoredQueries.includes(firstTwoQueries[i].id)) {
+      for (let i = 0; i < globalRelevantQueries.length; i++) {
+        if (!ignoredQueries.includes(globalRelevantQueries[i].id)) {
           ({ ignoredQueries, errorMessage = cloneErrorMessage } = await setIgnored(
-            firstTwoQueries[i].id,
+            globalRelevantQueries[i].id,
             true,
             ignoredQueries
           ));
@@ -197,27 +143,6 @@
     }
     fetchData();
   };
-
-  const elementDragEventUserQuery = () => {
-    updateQueryOrder(userQueries);
-  };
-
-  const elementDragEventAdminQuery = () => {
-    updateQueryOrder(adminQueries);
-  };
-
-  $: if (columnList) {
-    Sortable.create(columnList, {
-      animation: 150,
-      onEnd: elementDragEventUserQuery
-    });
-  }
-  $: if (columnListAdmin) {
-    Sortable.create(columnList, {
-      animation: 150,
-      onEnd: elementDragEventAdminQuery
-    });
-  }
 </script>
 
 <svelte:head>
@@ -246,228 +171,60 @@
   <Spinner color="gray" size="4"></Spinner>
 </div>
 <ErrorMessage error={errorMessage}></ErrorMessage>
-{#if queries.length > 0}
+{#if queries && queries.length > 0}
   <div class="flex flex-row flex-wrap gap-12">
-    <div class="mb-2 w-fit">
-      <span class="text-2xl">Personal</span>
-      <hr class="mb-6" />
-      <div class="max-h-[66vh] overflow-auto">
-        <Table hoverable={true} noborder={true}>
-          <TableHead>
-            <TableHeadCell padding={tablePadding}></TableHeadCell>
-            <TableHeadCell padding={tablePadding} on:click={() => {}}
-              >Name<i
-                class:bx={true}
-                class:bx-caret-up={orderBy == "name"}
-                class:bx-caret-down={orderBy == "-name"}
-              ></i></TableHeadCell
-            >
-            <TableHeadCell padding={tablePadding} on:click={() => {}}
-              >Description<i
-                class:bx={true}
-                class:bx-caret-up={orderBy == "description"}
-                class:bx-caret-down={orderBy == "-description"}
-              ></i>
-            </TableHeadCell>
-            <TableHeadCell padding={tablePadding} on:click={() => {}}>
-              <div>Dashboard</div>
-            </TableHeadCell>
-            <TableHeadCell padding={tablePadding} on:click={() => {}}>
-              <div>Hide</div>
-            </TableHeadCell>
-            <TableHeadCell></TableHeadCell>
-          </TableHead>
-          <tbody bind:this={columnList}>
-            {#each userQueries as query, index (index)}
-              <tr
-                on:click={() => {
-                  push(`/queries/${query.id}`);
-                }}
-                class="cursor-pointer"
-                ><TableBodyCell {tdClass}>
-                  <Img
-                    src="grid-dots-vertical-rounded.svg"
-                    class="h-4 min-h-2 min-w-2 invert-[.5]"
-                  />
-                </TableBodyCell>
-                <TableBodyCell {tdClass}>
-                  <span class="columnName">{query.name ?? "-"}</span>
-                </TableBodyCell>
-                <TableBodyCell {tdClass}>{query.description ?? "-"}</TableBodyCell>
-                <TableBodyCell {tdClass}>
-                  <CCheckbox
-                    on:click={(event) => {
-                      // @ts-expect-error Cannot use TS:
-                      // https://github.com/sveltejs/language-tools/blob/master/docs/preprocessors/typescript.md#can-i-use-typescript-syntax-inside-the-templatemustache-tags
-                      // But without ignore we would get an error.
-                      changeDashboard(query.id, event.explicitOriginalTarget?.checked);
-                    }}
-                    checked={query.dashboard}
-                  ></CCheckbox>
-                </TableBodyCell>
-                <TableBodyCell {tdClass}>
-                  <CCheckbox
-                    on:click={(event) => {
-                      // @ts-expect-error Cannot use TS (see explanation above)
-                      changeIgnored(query.id, event.explicitOriginalTarget?.checked);
-                    }}
-                    disabled={!ignoredQueries}
-                    checked={ignoredQueries.includes(query.id)}
-                  ></CCheckbox>
-                </TableBodyCell>
-                <td>
-                  <CIconButton
-                    title={`clone ${query.name}`}
-                    icon="copy"
-                    on:click={() => {
-                      push(`/queries/new?clone=${query.id}`);
-                    }}
-                  ></CIconButton>
-                  <CIconButton
-                    on:click={() => {
-                      querytoDelete = {
-                        name: query.name,
-                        id: query.id
-                      };
-                      deleteModalOpen = true;
-                    }}
-                    title={`delete ${query.name}`}
-                    icon="trash"
-                    color="red"
-                  ></CIconButton>
-                </td>
-              </tr>
-            {/each}
-          </tbody>
-        </Table>
-      </div>
-      <Button class="mb-6 mt-3" href="/#/queries/new"><i class="bx bx-plus"></i>New query</Button>
-      <ErrorMessage error={ignorePersonalErrorMessage}></ErrorMessage>
-    </div>
-    <div class="mb-2 w-fit">
-      <div class="mb-1 flex items-center gap-4">
-        <span class="text-2xl">Global</span>
-        {#if !appStore.isAdmin()}
-          <Button class="h-fit p-1 text-xs" on:click={cloneDashboardQueries} color="light"
-            >Clone global dashboard queries for my role and hide cloned queries (<span>*</span
-            >)</Button
-          >
-        {/if}
-      </div>
-      <hr class="mb-6" />
-      <div class="mb-2 max-h-[66vh] overflow-auto">
-        <Table hoverable={true} noborder={true}>
-          <TableHead>
-            <TableHeadCell padding={tablePadding}></TableHeadCell>
-            <TableHeadCell padding={tablePadding} on:click={() => {}}
-              >Name<i
-                class:bx={true}
-                class:bx-caret-up={orderBy == "name"}
-                class:bx-caret-down={orderBy == "-name"}
-              ></i></TableHeadCell
-            >
-            <TableHeadCell padding={tablePadding} on:click={() => {}}
-              >Description<i
-                class:bx={true}
-                class:bx-caret-up={orderBy == "description"}
-                class:bx-caret-down={orderBy == "-description"}
-              ></i>
-            </TableHeadCell>
-            <TableHeadCell padding={tablePadding} on:click={() => {}}>
-              <div>Dashboard</div>
-            </TableHeadCell>
-            <TableHeadCell padding={tablePadding} on:click={() => {}}>
-              <div title={"Show on your personal dashboard"}>Hide</div>
-            </TableHeadCell>
-            <TableHeadCell></TableHeadCell>
-          </TableHead>
-          <tbody bind:this={columnListAdmin}>
-            {#each adminQueries as query, index (index)}
-              <tr
-                on:click={() => {
-                  if (query.global && isRoleIncluded(appStore.getRoles(), [ADMIN])) {
-                    push(`/queries/${query.id}`);
-                  }
-                }}
-                class={!(query.global && !isRoleIncluded(appStore.getRoles(), [ADMIN]))
-                  ? "cursor-pointer"
-                  : ""}
-                ><TableBodyCell {tdClass}>
-                  {#if !(query.global && !isRoleIncluded(appStore.getRoles(), [ADMIN]))}
-                    <Img
-                      src="grid-dots-vertical-rounded.svg"
-                      class="h-4 min-h-2 min-w-2 invert-[.5]"
-                    />
-                  {/if}
-                </TableBodyCell>
-                <TableBodyCell {tdClass}>
-                  <span>{query.name ?? "-"}</span><span
-                    >{!appStore.isAdmin() && firstTwoQueries.find((q) => q.id === query.id)
-                      ? "*"
-                      : ""}</span
-                  >
-                </TableBodyCell>
-                <TableBodyCell {tdClass}>{query.description ?? "-"}</TableBodyCell>
-                <TableBodyCell {tdClass}>
-                  <CCheckbox
-                    on:click={(event) => {
-                      // @ts-expect-error Cannot use TS (see explanation above)
-                      changeDashboard(query.id, event.explicitOriginalTarget?.checked);
-                    }}
-                    checked={query.dashboard}
-                    class={appStore.isAdmin() ? "" : "text-gray-300"}
-                    disabled={!appStore.isAdmin()}
-                  ></CCheckbox>
-                </TableBodyCell>
-                <TableBodyCell {tdClass}>
-                  <CCheckbox
-                    on:click={(event) => {
-                      // @ts-expect-error Cannot use TS (see explanation above)
-                      changeIgnored(query.id, event.explicitOriginalTarget?.checked);
-                    }}
-                    disabled={!ignoredQueries}
-                    checked={ignoredQueries.includes(query.id)}
-                  ></CCheckbox>
-                </TableBodyCell>
-                <td>
-                  {#if !firstTwoQueries.find((q) => q.id === query.id) || appStore.isAdmin()}
-                    <CIconButton
-                      title={`clone ${query.name}`}
-                      icon="copy"
-                      on:click={() => {
-                        push(`/queries/new?clone=${query.id}`);
-                      }}
-                    ></CIconButton>
-                  {/if}
-                  {#if !(query.global && !isRoleIncluded(appStore.getRoles(), [ADMIN]))}
-                    <CIconButton
-                      on:click={() => {
-                        querytoDelete = {
-                          name: query.name,
-                          id: query.id
-                        };
-                        deleteModalOpen = true;
-                      }}
-                      title={`delete ${query.name}`}
-                      icon="trash"
-                      color="red"
-                    ></CIconButton>
-                  {/if}
-                </td>
-              </tr>
-            {/each}
-          </tbody>
-        </Table>
-      </div>
-      <div class="flex flex-col">
-        {#if appStore.isAdmin()}
-          <Button class="mb-2 mt-3 w-fit" href="/#/queries/new"
-            ><i class="bx bx-plus"></i>New query</Button
-          >
-        {/if}
-        <ErrorMessage error={ignoreGlobalErrorMessage}></ErrorMessage>
+    <QueryTable
+      isAllowedToEdit={true}
+      queries={userQueries}
+      title="Personal"
+      on:fetchData={fetchData}
+      on:openDeleteModal={onOpenDeleteModal}
+    >
+      <Button class="mb-2 mt-3 w-fit" href="/#/queries/new"
+        ><i class="bx bx-plus me-2"></i>New query</Button
+      >
+    </QueryTable>
+
+    {#if !appStore.isAdmin()}
+      <QueryTable
+        isAllowedToClone={false}
+        queries={globalRelevantQueries}
+        title="Global relevant dashboard queries"
+        on:fetchData={fetchData}
+        on:openDeleteModal={onOpenDeleteModal}
+      >
         <ErrorMessage error={cloneErrorMessage}></ErrorMessage>
-      </div>
-    </div>
+        <Button class="h-fit w-fit text-sm" on:click={cloneDashboardQueries}>
+          <i class="bx bx-copy me-2"></i>
+          <span>Clone relevant queries and hide cloned queries</span>
+        </Button>
+      </QueryTable>
+
+      <QueryTable
+        queries={globalDashboardQueries}
+        title="Global dashboard queries (not displayed)"
+        on:fetchData={fetchData}
+        on:openDeleteModal={onOpenDeleteModal}
+      ></QueryTable>
+
+      <QueryTable
+        queries={globalSearchQueries}
+        title="Global search queries"
+        on:fetchData={fetchData}
+        on:openDeleteModal={onOpenDeleteModal}
+      ></QueryTable>
+    {:else}
+      <QueryTable
+        queries={adminQueries}
+        title="Global"
+        isAllowedToEdit={appStore.isAdmin()}
+        on:fetchData={fetchData}
+        on:openDeleteModal={onOpenDeleteModal}
+      >
+        <Button class="mb-2 mt-3 w-fit" href="/#/queries/new"
+          ><i class="bx bx-plus me-2"></i>New query</Button
+        >
+      </QueryTable>
+    {/if}
   </div>
 {/if}

--- a/client/src/lib/Queries/QueryDesigner.svelte
+++ b/client/src/lib/Queries/QueryDesigner.svelte
@@ -170,14 +170,14 @@
         );
     }
     if (response.ok) {
-      const id = params ? params.id : response.content.id;
+      const id: string = params ? params.id : response.content.id;
       saveErrorMessage = errorMessage;
       if (
         (!ignoredQueries.includes(Number(id)) && hide === true) ||
         (ignoredQueries.includes(Number(id)) && hide === false)
       ) {
         const ignore = !ignoredQueries.includes(Number(id)) && hide === true;
-        ({ errorMessage } = await setIgnored(id, ignore, ignoredQueries));
+        ({ errorMessage } = await setIgnored(Number(id), ignore));
         saveErrorMessage = errorMessage;
         if (errorMessage === null) {
           push(`/queries/`);

--- a/client/src/lib/Queries/QueryDesigner.svelte
+++ b/client/src/lib/Queries/QueryDesigner.svelte
@@ -29,7 +29,9 @@
     generateQueryString,
     type Search,
     type Column,
-    proposeName
+    proposeName,
+    setIgnored,
+    fetchIgnored
   } from "$lib/Queries/query";
   import ErrorMessage from "$lib/Errors/ErrorMessage.svelte";
   import { getErrorDetails, type ErrorDetails } from "$lib/Errors/error";
@@ -50,8 +52,9 @@
   let loadQueryError: ErrorDetails | null;
   let loadedData: any = null;
   let abortController: AbortController;
-
   let columnList: any;
+  let hide = false;
+  let ignoredQueries: number[] = [];
 
   // Prop items of (Multi-)Select doesn't accept simple strings
   const roles = [{ name: "<no role>", value: "" }].concat(
@@ -167,7 +170,21 @@
         );
     }
     if (response.ok) {
-      push(`/queries/`);
+      const id = params ? params.id : response.content.id;
+      saveErrorMessage = errorMessage;
+      if (
+        (!ignoredQueries.includes(Number(id)) && hide === true) ||
+        (ignoredQueries.includes(Number(id)) && hide === false)
+      ) {
+        const ignore = !ignoredQueries.includes(Number(id)) && hide === true;
+        ({ errorMessage } = await setIgnored(id, ignore, ignoredQueries));
+        saveErrorMessage = errorMessage;
+        if (errorMessage === null) {
+          push(`/queries/`);
+        }
+      } else {
+        push(`/queries/`);
+      }
     }
   };
 
@@ -261,7 +278,9 @@
       wasNameEdited = true;
     }
     if (params) id = params.id;
+    ({ ignoredQueries, errorMessage } = await fetchIgnored());
     if (id) {
+      if (ignoredQueries.includes(Number(id))) hide = true;
       const response = await request(`/api/queries`, "GET");
       if (response.ok) {
         const result = await response.content;
@@ -355,6 +374,10 @@
             currentSearch.dashboard = !currentSearch.dashboard;
           }}
         ></CCheckbox>
+      </div>
+      <div class="flex flex-row items-center gap-x-2">
+        <span>Hide:</span>
+        <CCheckbox bind:checked={hide}></CCheckbox>
       </div>
     </div>
     <div class="mb-6">

--- a/client/src/lib/Queries/QueryTable.svelte
+++ b/client/src/lib/Queries/QueryTable.svelte
@@ -23,7 +23,7 @@
 
   export let title = "";
   export let queries: Query[] | undefined = [];
-  export let ignoredQueries: number[] = [];
+  export let ignoredQueries: number[] | null = null;
   export let isAllowedToEdit = false;
   export let isAllowedToClone = true;
 
@@ -85,13 +85,15 @@
   };
 
   const changeIgnored = async (id: number, isChecked: boolean) => {
-    unsetErrors();
-    ({ ignoredQueries, errorMessage: ignoreErrorMessage } = await setIgnored(
-      id,
-      isChecked,
-      ignoredQueries
-    ));
-    if (ignoreErrorMessage !== null) dispatch("fetchData");
+    if (ignoredQueries) {
+      unsetErrors();
+      ({ ignoredQueries, errorMessage: ignoreErrorMessage } = await setIgnored(
+        id,
+        isChecked,
+        ignoredQueries
+      ));
+      if (ignoreErrorMessage !== null) dispatch("fetchData");
+    }
   };
 
   const changeDashboard = async (id: number, isChecked: boolean) => {
@@ -179,8 +181,8 @@
                     // @ts-expect-error Cannot use TS (see explanation above)
                     changeIgnored(query.id, event.explicitOriginalTarget?.checked);
                   }}
-                  disabled={!ignoredQueries || !isAllowedToEdit}
-                  checked={ignoredQueries.includes(query.id)}
+                  disabled={!ignoredQueries}
+                  checked={ignoredQueries !== null && ignoredQueries.includes(query.id)}
                 ></CCheckbox>
               </TableBodyCell>
               <td>

--- a/client/src/lib/Queries/QueryTable.svelte
+++ b/client/src/lib/Queries/QueryTable.svelte
@@ -92,7 +92,7 @@
         isChecked,
         ignoredQueries
       ));
-      if (ignoreErrorMessage !== null) dispatch("fetchData");
+      if (ignoreErrorMessage === null) dispatch("fetchData");
     }
   };
 

--- a/client/src/lib/Queries/QueryTable.svelte
+++ b/client/src/lib/Queries/QueryTable.svelte
@@ -39,6 +39,7 @@
   let cloneErrorMessage: ErrorDetails | null = null;
   let orderErrorMessage: ErrorDetails | null = null;
   let columnList: any;
+  let isLoading = false;
 
   const updateQueryOrder = async (queries: Query[]) => {
     let nodes = columnList.querySelectorAll(".columnName");
@@ -85,6 +86,7 @@
   };
 
   const changeIgnored = async (id: number, isChecked: boolean) => {
+    isLoading = true;
     if (ignoredQueries) {
       unsetErrors();
       ({ ignoredQueries, errorMessage: ignoreErrorMessage } = await setIgnored(
@@ -94,9 +96,11 @@
       ));
       if (ignoreErrorMessage === null) dispatch("fetchData");
     }
+    isLoading = false;
   };
 
   const changeDashboard = async (id: number, isChecked: boolean) => {
+    isLoading = true;
     unsetErrors();
     if (queries) {
       const queryToUpdate = queries.filter((q) => q.id === id)[0];
@@ -108,6 +112,7 @@
         }
       }
     }
+    isLoading = false;
   };
 </script>
 
@@ -172,7 +177,7 @@
                   }}
                   checked={query.dashboard}
                   class={isAllowedToEdit ? "" : "text-gray-300"}
-                  disabled={!isAllowedToEdit}
+                  disabled={!isAllowedToEdit || isLoading}
                 ></CCheckbox>
               </TableBodyCell>
               <TableBodyCell {tdClass}>
@@ -181,7 +186,7 @@
                     // @ts-expect-error Cannot use TS (see explanation above)
                     changeIgnored(query.id, event.explicitOriginalTarget?.checked);
                   }}
-                  disabled={!ignoredQueries}
+                  disabled={!ignoredQueries || isLoading}
                   checked={ignoredQueries !== null && ignoredQueries.includes(query.id)}
                 ></CCheckbox>
               </TableBodyCell>

--- a/client/src/lib/Queries/QueryTable.svelte
+++ b/client/src/lib/Queries/QueryTable.svelte
@@ -111,7 +111,7 @@
   };
 </script>
 
-<div class="mb-2 w-fit">
+<div class="w-fit">
   <div class="mb-1 flex items-center gap-4">
     <span class="text-2xl">{title}</span>
   </div>
@@ -222,8 +222,10 @@
   </div>
   <div class="flex flex-col">
     <slot></slot>
-    <ErrorMessage error={ignoreErrorMessage}></ErrorMessage>
-    <ErrorMessage error={cloneErrorMessage}></ErrorMessage>
-    <ErrorMessage error={orderErrorMessage}></ErrorMessage>
   </div>
+</div>
+<div class="flex flex-col">
+  <ErrorMessage error={ignoreErrorMessage}></ErrorMessage>
+  <ErrorMessage error={cloneErrorMessage}></ErrorMessage>
+  <ErrorMessage error={orderErrorMessage}></ErrorMessage>
 </div>

--- a/client/src/lib/Queries/QueryTable.svelte
+++ b/client/src/lib/Queries/QueryTable.svelte
@@ -171,9 +171,8 @@
               <TableBodyCell {tdClass}>{query.description ?? "-"}</TableBodyCell>
               <TableBodyCell {tdClass}>
                 <CCheckbox
-                  on:click={(event) => {
-                    // @ts-expect-error Cannot use TS (see explanation above)
-                    changeDashboard(query.id, event.explicitOriginalTarget?.checked);
+                  on:click={() => {
+                    changeDashboard(query.id, !ignoredQueries?.includes(query.id));
                   }}
                   checked={query.dashboard}
                   class={isAllowedToEdit ? "" : "text-gray-300"}
@@ -182,9 +181,8 @@
               </TableBodyCell>
               <TableBodyCell {tdClass}>
                 <CCheckbox
-                  on:click={(event) => {
-                    // @ts-expect-error Cannot use TS (see explanation above)
-                    changeIgnored(query.id, event.explicitOriginalTarget?.checked);
+                  on:click={() => {
+                    changeIgnored(query.id, !ignoredQueries?.includes(query.id));
                   }}
                   disabled={!ignoredQueries || isLoading}
                   checked={ignoredQueries !== null && ignoredQueries.includes(query.id)}

--- a/client/src/lib/Queries/QueryTable.svelte
+++ b/client/src/lib/Queries/QueryTable.svelte
@@ -1,0 +1,227 @@
+<!--
+ This file is Free Software under the Apache-2.0 License
+ without warranty, see README.md and LICENSES/Apache-2.0.txt for details.
+
+ SPDX-License-Identifier: Apache-2.0
+
+ SPDX-FileCopyrightText: 2024 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+ Software-Engineering: 2024 Intevation GmbH <https://intevation.de>
+-->
+
+<script lang="ts">
+  import { Img, Table, TableHead, TableHeadCell, TableBodyCell } from "flowbite-svelte";
+  import { tablePadding, tdClass } from "$lib/Table/defaults";
+  import CCheckbox from "$lib/Components/CCheckbox.svelte";
+  import CIconButton from "$lib/Components/CIconButton.svelte";
+  import { createEventDispatcher } from "svelte";
+  import { setIgnored, updateStoredQuery, type Query } from "./query";
+  import { push } from "svelte-spa-router";
+  import ErrorMessage from "$lib/Errors/ErrorMessage.svelte";
+  import { getErrorDetails, type ErrorDetails } from "$lib/Errors/error";
+  import Sortable from "sortablejs";
+  import { request } from "$lib/request";
+
+  export let title = "";
+  export let queries: Query[] | undefined = [];
+  export let ignoredQueries: number[] = [];
+  export let isAllowedToEdit = false;
+  export let isAllowedToClone = true;
+
+  const dispatch = createEventDispatcher();
+
+  const resetQueryToDelete = () => {
+    return { name: "", id: -1 };
+  };
+
+  let orderBy = "";
+  let querytoDelete: any = resetQueryToDelete();
+  let ignoreErrorMessage: ErrorDetails | null = null;
+  let cloneErrorMessage: ErrorDetails | null = null;
+  let orderErrorMessage: ErrorDetails | null = null;
+  let columnList: any;
+
+  const updateQueryOrder = async (queries: Query[]) => {
+    let nodes = columnList.querySelectorAll(".columnName");
+    type Order = {
+      id: number;
+      order: number;
+    };
+    let orders: Order[] = [];
+    let i = 0;
+    for (const node of nodes) {
+      let columnName = node.innerText;
+      let query = queries.find((q) => q.name === columnName);
+      if (query) {
+        orders.push({ id: query.id, order: i });
+      }
+      i++;
+    }
+
+    let response = await request(`/api/queries/orders`, "POST", JSON.stringify(orders));
+    if (!response.ok && response.error) {
+      orderErrorMessage = getErrorDetails(`Could not update query order.`, response);
+    }
+    if (response.ok) {
+      push(`/queries/`);
+    }
+  };
+
+  const elementDragEventUserQuery = () => {
+    if (queries) {
+      updateQueryOrder(queries);
+    }
+  };
+
+  $: if (columnList) {
+    Sortable.create(columnList, {
+      animation: 150,
+      onEnd: elementDragEventUserQuery
+    });
+  }
+
+  const unsetErrors = () => {
+    ignoreErrorMessage = null;
+    cloneErrorMessage = null;
+  };
+
+  const changeIgnored = async (id: number, isChecked: boolean) => {
+    unsetErrors();
+    ({ ignoredQueries, errorMessage: ignoreErrorMessage } = await setIgnored(
+      id,
+      isChecked,
+      ignoredQueries
+    ));
+    if (ignoreErrorMessage !== null) dispatch("fetchData");
+  };
+
+  const changeDashboard = async (id: number, isChecked: boolean) => {
+    unsetErrors();
+    if (queries) {
+      const queryToUpdate = queries.filter((q) => q.id === id)[0];
+      if (queryToUpdate) {
+        queryToUpdate.dashboard = isChecked;
+        const response = await updateStoredQuery(queryToUpdate);
+        if (!response.ok && response.error) {
+          ignoreErrorMessage = getErrorDetails(`Could not change option.`, response);
+        }
+      }
+    }
+  };
+</script>
+
+<div class="mb-2 w-fit">
+  <div class="mb-1 flex items-center gap-4">
+    <span class="text-2xl">{title}</span>
+  </div>
+  <hr class="mb-6" />
+  <div class="mb-2 max-h-[66vh] overflow-auto">
+    <Table hoverable={true} noborder={true}>
+      <TableHead>
+        <TableHeadCell padding={tablePadding}></TableHeadCell>
+        <TableHeadCell padding={tablePadding} on:click={() => {}}
+          >Name<i
+            class:bx={true}
+            class:bx-caret-up={orderBy == "name"}
+            class:bx-caret-down={orderBy == "-name"}
+          ></i></TableHeadCell
+        >
+        <TableHeadCell padding={tablePadding} on:click={() => {}}
+          >Description<i
+            class:bx={true}
+            class:bx-caret-up={orderBy == "description"}
+            class:bx-caret-down={orderBy == "-description"}
+          ></i>
+        </TableHeadCell>
+        <TableHeadCell padding={tablePadding} on:click={() => {}}>
+          <div>Dashboard</div>
+        </TableHeadCell>
+        <TableHeadCell padding={tablePadding} on:click={() => {}}>
+          <div title={"Show on your personal dashboard"}>Hide</div>
+        </TableHeadCell>
+        <TableHeadCell></TableHeadCell>
+      </TableHead>
+      {#if queries !== undefined && queries.length > 0}
+        <tbody bind:this={columnList}>
+          {#each queries as query, index (index)}
+            <tr
+              on:click={() => {
+                if (isAllowedToEdit) {
+                  push(`/queries/${query.id}`);
+                }
+              }}
+              class={isAllowedToEdit ? "cursor-pointer" : ""}
+              ><TableBodyCell {tdClass}>
+                {#if isAllowedToEdit}
+                  <Img
+                    src="grid-dots-vertical-rounded.svg"
+                    class="h-4 min-h-2 min-w-2 invert-[.5]"
+                  />
+                {/if}
+              </TableBodyCell>
+              <TableBodyCell {tdClass}>
+                <span>{query.name ?? "-"}</span>
+              </TableBodyCell>
+              <TableBodyCell {tdClass}>{query.description ?? "-"}</TableBodyCell>
+              <TableBodyCell {tdClass}>
+                <CCheckbox
+                  on:click={(event) => {
+                    // @ts-expect-error Cannot use TS (see explanation above)
+                    changeDashboard(query.id, event.explicitOriginalTarget?.checked);
+                  }}
+                  checked={query.dashboard}
+                  class={isAllowedToEdit ? "" : "text-gray-300"}
+                  disabled={!isAllowedToEdit}
+                ></CCheckbox>
+              </TableBodyCell>
+              <TableBodyCell {tdClass}>
+                <CCheckbox
+                  on:click={(event) => {
+                    // @ts-expect-error Cannot use TS (see explanation above)
+                    changeIgnored(query.id, event.explicitOriginalTarget?.checked);
+                  }}
+                  disabled={!ignoredQueries || !isAllowedToEdit}
+                  checked={ignoredQueries.includes(query.id)}
+                ></CCheckbox>
+              </TableBodyCell>
+              <td>
+                {#if !queries.find((q) => q.id === query.id) || isAllowedToClone}
+                  <CIconButton
+                    title={`clone ${query.name}`}
+                    icon="copy"
+                    on:click={() => {
+                      push(`/queries/new?clone=${query.id}`);
+                    }}
+                  ></CIconButton>
+                {/if}
+                {#if isAllowedToEdit}
+                  <CIconButton
+                    on:click={() => {
+                      querytoDelete = {
+                        name: query.name,
+                        id: query.id
+                      };
+                      dispatch("openDeleteModal", querytoDelete);
+                    }}
+                    title={`delete ${query.name}`}
+                    icon="trash"
+                    color="red"
+                  ></CIconButton>
+                {/if}
+              </td>
+            </tr>
+          {/each}
+        </tbody>
+      {:else if queries !== undefined && queries.length === 0}
+        <tbody>
+          <span>No queries found</span>
+        </tbody>
+      {/if}
+    </Table>
+  </div>
+  <div class="flex flex-col">
+    <slot></slot>
+    <ErrorMessage error={ignoreErrorMessage}></ErrorMessage>
+    <ErrorMessage error={cloneErrorMessage}></ErrorMessage>
+    <ErrorMessage error={orderErrorMessage}></ErrorMessage>
+  </div>
+</div>

--- a/client/src/lib/Queries/QueryTable.svelte
+++ b/client/src/lib/Queries/QueryTable.svelte
@@ -225,10 +225,8 @@
   </div>
   <div class="flex flex-col">
     <slot></slot>
+    <ErrorMessage error={ignoreErrorMessage}></ErrorMessage>
+    <ErrorMessage error={cloneErrorMessage}></ErrorMessage>
+    <ErrorMessage error={orderErrorMessage}></ErrorMessage>
   </div>
-</div>
-<div class="flex flex-col">
-  <ErrorMessage error={ignoreErrorMessage}></ErrorMessage>
-  <ErrorMessage error={cloneErrorMessage}></ErrorMessage>
-  <ErrorMessage error={orderErrorMessage}></ErrorMessage>
 </div>

--- a/client/src/lib/Queries/QueryTable.svelte
+++ b/client/src/lib/Queries/QueryTable.svelte
@@ -89,12 +89,12 @@
     isLoading = true;
     if (ignoredQueries) {
       unsetErrors();
-      ({ ignoredQueries, errorMessage: ignoreErrorMessage } = await setIgnored(
+      let newIgnored: number[] | null = null;
+      ({ ignoredQueries: newIgnored, errorMessage: ignoreErrorMessage } = await setIgnored(
         id,
-        isChecked,
-        ignoredQueries
+        isChecked
       ));
-      if (ignoreErrorMessage === null) dispatch("fetchData");
+      if (ignoreErrorMessage === null) dispatch("updateIgnored", newIgnored);
     }
     isLoading = false;
   };

--- a/client/src/lib/Queries/query.ts
+++ b/client/src/lib/Queries/query.ts
@@ -255,19 +255,19 @@ const proposeName = (queries: Query[], name: string) => {
   return `${name} (${highestIndex + 1})`;
 };
 
-const setIgnored = async (id: number, isChecked: boolean, ignoredQueries: number[]) => {
-  let errorMessage: ErrorDetails | null = null;
-  const method = isChecked ? "POST" : "DELETE";
-  const response = await request(`/api/queries/ignore/${id}`, method);
-  if (response.ok) {
-    if (isChecked) {
-      ignoredQueries.push(id);
-    } else {
-      ignoredQueries = ignoredQueries.filter((i) => i !== id);
-    }
-  } else if (response.error) {
-    errorMessage = getErrorDetails(`Could not change option.`, response);
+const setIgnored = async (id: number, doIgnore: boolean) => {
+  let { ignoredQueries, errorMessage } = await fetchIgnored();
+  if (errorMessage != null) return { ignoredQueries, errorMessage };
+  if ((doIgnore && ignoredQueries.includes(id)) || (!doIgnore && !ignoredQueries.includes(id))) {
+    return { ignoredQueries, errorMessage: null };
   }
+  const method = doIgnore ? "POST" : "DELETE";
+  const response = await request(`/api/queries/ignore/${id}`, method);
+  if (response.error) {
+    errorMessage = getErrorDetails(`Could not change option.`, response);
+    return { ignoredQueries, errorMessage };
+  }
+  ({ ignoredQueries, errorMessage } = await fetchIgnored());
   return { ignoredQueries, errorMessage };
 };
 

--- a/client/src/lib/Search/Queries.svelte
+++ b/client/src/lib/Search/Queries.svelte
@@ -65,7 +65,7 @@
     fetchIgnored();
     const response = await request("/api/queries", "GET");
     if (response.ok) {
-      queries = response.content;
+      queries = response.content.filter((q: any) => !q.dashboard);
     } else if (response.error) {
       errorMessage = getErrorDetails(`Could not load user defined queries.`, response);
     }

--- a/docs/developer/queries.md
+++ b/docs/developer/queries.md
@@ -33,6 +33,18 @@ Alternatives considered (and not implemented):
     in the search list at the same time as the personal
     modified cloned queries.)
 
+### Default dashboard queries
+
+To support users to fulfill their role in a good way we store some queries
+in `stored_queries` as part of the migrations. Since we don't know the names of
+the accounts the admins will be using we add `system-default` as `definer` of the
+these queries.
+
+If some admin would decide to save these queries as non-global it could happen
+that the queries would be lost because in this case they would belong to
+`system-default`. If there would be no such user as admin this meant that no
+one could ever set the queries to global again. Therefore, we prevent
+setting the default queries to non-global.
 
 ### client does the selection
 

--- a/docs/developer/queries.md
+++ b/docs/developer/queries.md
@@ -59,8 +59,6 @@ via the ignored table.
 
 #### editing user interface
 
-##### Idea of special clone button
-
 A special button ala "Clone the global dashboard queries for me"
 will copy the two global queries, mark the copies as
 for the dashboard, puts them into the first position
@@ -70,12 +68,5 @@ This button avoids the problem that if only the second
 global query is cloned, it would be the first to be displayed
 under the calculation rule above.
 
-The idea was discarded for the reason that an
-admin add new queries and re-order all queries so that
-the default queries were not at the first two positions. If the user
-then clones the first two global queries these maybe are not the
-pre-defined ones. We could mark these queries as pre-defined by
-using another attribute in the SQL table or using a
-naming convention but that would make things more complicate
-than necessary.
+
 

--- a/pkg/database/migrations/000-setup.sql
+++ b/pkg/database/migrations/000-setup.sql
@@ -427,6 +427,7 @@ GRANT INSERT, DELETE, SELECT, UPDATE ON downloads               TO {{ .User | sa
 --
 DO $$
 DECLARE
+    -- See explanation for definer in docs/developer/queries.md
     default_definer constant varchar = 'system-default';
     default_advisory_columns text array default Array['cvss_v3_score', 'cvss_v2_score', 'comments', 'critical', 'id', 'recent', 'versions', 'title', 'publisher', 'ssvc', 'state', 'tracking_id'];
     default_event_columns text array default Array['cvss_v3_score', 'cvss_v2_score', 'comments', 'critical', 'id', 'title', 'publisher', 'ssvc', 'tracking_id', 'event', 'event_state', 'time', 'actor', 'comments_id'];


### PR DESCRIPTION
- Fixes #333
- Makes it more clear which queries are the default ones in the query overview
- dashboard queries are only visible on the dashboard (not in the search)
- non-dashboard queries are only visible in the search
- `global` cannot be removed from default queries (will only be prevented by the backend but that's enough for now)