### PR TITLE
fix: No longer give logging info that needs to be manually approved

### DIFF
--- a/docs/scripts/configurepostgres.sh
+++ b/docs/scripts/configurepostgres.sh
@@ -14,8 +14,6 @@ set -e # to exit if a command in the script fails
 LAB="#listen_addresses = 'localhost'" # Listen Adress Before
 LAA="listen_addresses = '*'"          # Listen Adress After
 
-systemctl status postgresql
-
 # Alter PostgreSQL as postgres user
 psql -c "ALTER USER postgres WITH PASSWORD 'postgres';"
 


### PR DESCRIPTION
Currently setup scripts won't always automatically run through but stop at the systemstatus of postgres. Unless there's a failure this is not  necessary, so removing it so it can run through smoothly.