### PR TITLE
Source Manager: Fix Go routine leak in downloader

### DIFF
--- a/pkg/sources/download.go
+++ b/pkg/sources/download.go
@@ -76,8 +76,7 @@ func (i *inserter) sql(table string) string {
 
 // download fetches the files of a document and stores
 // them into the database.
-func (l location) download(m *Manager, f *feed, done func()) {
-	defer done()
+func (l location) download(m *Manager, f *feed) {
 
 	var (
 		strictMode     bool                     // All checks have to be fulfilled.

--- a/pkg/sources/manager.go
+++ b/pkg/sources/manager.go
@@ -14,7 +14,6 @@ import (
 	"log/slog"
 	"net/url"
 	"regexp"
-	"runtime"
 	"slices"
 	"strconv"
 	"strings"
@@ -277,7 +276,6 @@ func (dj *downloadJob) finish(m *Manager) {
 			l.state = done
 		}
 	}
-	fmt.Printf("Number of Go-Routines: %d\n", runtime.NumGoroutine())
 }
 
 func (m *Manager) download(wg *sync.WaitGroup) {

--- a/pkg/sources/manager.go
+++ b/pkg/sources/manager.go
@@ -14,9 +14,11 @@ import (
 	"log/slog"
 	"net/url"
 	"regexp"
+	"runtime"
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/ISDuBA/ISDuBA/pkg/config"
@@ -53,11 +55,17 @@ func (InvalidArgumentError) Is(target error) bool {
 // refreshDuration is the fallback duration for feeds to be checked for refresh.
 const refreshDuration = time.Minute
 
+type downloadJob struct {
+	l location
+	f *feed
+}
+
 // Manager fetches advisories from sources.
 type Manager struct {
 	cfg  *config.Config
 	db   *database.DB
 	fns  chan func(*Manager)
+	jobs chan downloadJob
 	done bool
 
 	cipherKey []byte
@@ -148,6 +156,7 @@ func NewManager(
 		cfg:       cfg,
 		db:        db,
 		fns:       make(chan func(*Manager)),
+		jobs:      make(chan downloadJob),
 		cipherKey: cipherKey,
 		pmdCache:  newPMDCache(),
 		keysCache: newKeysCache(cfg.Sources.OpenPGPCaching),
@@ -242,24 +251,40 @@ func (m *Manager) startDownloads() {
 				return true
 			}
 			// Find a candidate to download.
-			location := f.findWaiting()
-			if location == nil {
+			loc := f.findWaiting()
+			if loc == nil {
 				return true
 			}
 			m.usedSlots++
 			f.source.usedSlots++
-			location.state = running
-			location.id = m.generateID()
+			loc.state = running
+			loc.id = m.generateID()
 			started = true
-			// Funtion to be called when the download is finished.
-			done := m.downloadDone(f, location.id)
-			// Calling reciever by value is intended here!
-			go (*location).download(m, f, done)
+			m.jobs <- downloadJob{l: *loc, f: f}
 			return m.usedSlots < m.cfg.Sources.DownloadSlots
 		})
 		if !started {
 			return
 		}
+	}
+}
+
+func (dj *downloadJob) finish(m *Manager) {
+	m.fns <- func(m *Manager) {
+		dj.f.source.usedSlots = max(0, dj.f.source.usedSlots-1)
+		m.usedSlots = max(0, m.usedSlots-1)
+		if l := dj.f.findLocationByID(dj.l.id); l != nil {
+			l.state = done
+		}
+	}
+	fmt.Printf("Number of Go-Routines: %d\n", runtime.NumGoroutine())
+}
+
+func (m *Manager) download(wg *sync.WaitGroup) {
+	defer wg.Done()
+	for job := range m.jobs {
+		job.l.download(m, job.f)
+		job.finish(m)
 	}
 }
 
@@ -281,8 +306,16 @@ func (m *Manager) generateID() int64 {
 
 // Run runs the manager. To be used in a Go routine.
 func (m *Manager) Run(ctx context.Context) {
+
+	var wg sync.WaitGroup
+
+	for range m.cfg.Sources.DownloadSlots {
+		go m.download(&wg)
+	}
+
 	refreshTicker := time.NewTicker(refreshDuration)
 	defer refreshTicker.Stop()
+out:
 	for !m.done {
 		m.pmdCache.Cleanup()
 		m.keysCache.Cleanup()
@@ -293,10 +326,12 @@ func (m *Manager) Run(ctx context.Context) {
 		case fn := <-m.fns:
 			fn(m)
 		case <-ctx.Done():
-			return
+			break out
 		case <-refreshTicker.C:
 		}
 	}
+	close(m.jobs)
+	wg.Wait()
 }
 
 // Source returns infos about a source.
@@ -760,21 +795,6 @@ func (m *Manager) RemoveSource(sourceID int64) error {
 // RemoveFeed removes a feed from a source.
 func (m *Manager) RemoveFeed(feedID int64) error {
 	return m.asManager((*Manager).removeFeed, feedID)
-}
-
-// downloadDone returns a function which does the needed
-// book keeping when a download is finished. To be used
-// as a defer function in the download.
-func (m *Manager) downloadDone(f *feed, id int64) func() {
-	return func() {
-		m.fns <- func(m *Manager) {
-			f.source.usedSlots = max(0, f.source.usedSlots-1)
-			m.usedSlots = max(0, m.usedSlots-1)
-			if l := f.findLocationByID(id); l != nil {
-				l.state = done
-			}
-		}
-	}
 }
 
 // PMD returns the provider metadata from the given url.

--- a/pkg/sources/manager.go
+++ b/pkg/sources/manager.go
@@ -310,6 +310,7 @@ func (m *Manager) Run(ctx context.Context) {
 	var wg sync.WaitGroup
 
 	for range m.cfg.Sources.DownloadSlots {
+		wg.Add(1)
 		go m.download(&wg)
 	}
 


### PR DESCRIPTION
This PR fixes a Go routine leak in the Source manger.

* The HTTP clients are now closed as are the HTTP request (needed)
* The downloads are now done with a worker pool. This is not really needed but reduces the number of Go routines.

closes #446 