### PR TITLE
Restyle advisory detail view

### DIFF
--- a/client/src/lib/Advisories/Advisory.svelte
+++ b/client/src/lib/Advisories/Advisory.svelte
@@ -338,7 +338,7 @@
   <ErrorMessage error={loadFourCVEsError}></ErrorMessage>
   <div class="w-full lg:grid lg:grid-cols-[1fr_29rem]">
     <div
-      class="right-3 mr-3 flex w-[29rem] flex-col bg-white lg:order-2 lg:max-h-full lg:flex-none lg:overflow-auto"
+      class="right-3 mr-3 flex w-full flex-col bg-white lg:order-2 lg:max-h-full lg:w-[29rem] lg:flex-none lg:overflow-auto"
     >
       <div class={isSSVCediting || commentFocus ? " w-full p-3 shadow-md" : "w-full p-3"}>
         <div class="mb-4 flex flex-row items-center">
@@ -383,9 +383,9 @@
         {/if}
       </div>
       <ErrorMessage error={loadDocumentSSVCError}></ErrorMessage>
-      <div class="">
+      <div class="h-auto">
         {#if appStore.isEditor() || appStore.isReviewer() || appStore.isAuditor()}
-          <div class="mt-6">
+          <div class="mt-6 h-full">
             <History
               state={advisoryState}
               on:commentUpdate={() => {

--- a/client/src/lib/Advisories/Advisory.svelte
+++ b/client/src/lib/Advisories/Advisory.svelte
@@ -316,122 +316,117 @@
   <title>{params.trackingID}</title>
 </svelte:head>
 
-<div
-  class="flex h-screen max-h-full flex-wrap justify-between gap-x-4 gap-y-8 xl:flex-nowrap"
-  id="top"
->
-  <div class="flex max-h-full w-full grow flex-col gap-y-2 px-2">
-    <div class="flex flex-col">
-      <div class="flex gap-2">
-        <Label class="text-lg">
-          <span class="mr-2">{params.trackingID}</span>
-          <Tlp tlp={$appStore.webview.doc?.tlp.label}></Tlp>
-        </Label>
-      </div>
-      <div class="flex flex-row flex-wrap items-end justify-start gap-y-2 md:justify-between">
-        <Label class="text-gray-600">{params.publisherNamespace}</Label>
-        <div class="right-6 mt-4 flex h-fit flex-row gap-2 min-[1080px]:absolute">
-          <WorkflowStates {advisoryState} updateStateFn={updateState}></WorkflowStates>
-        </div>
-      </div>
-      <div class="mb-4 mt-2" />
+<div class="grid h-full w-full grow grid-rows-[auto_minmax(100px,_1fr)] gap-y-2 px-2" id="top">
+  <div class="flex flex-none flex-col">
+    <div class="flex gap-2">
+      <Label class="text-lg">
+        <span class="mr-2">{params.trackingID}</span>
+        <Tlp tlp={$appStore.webview.doc?.tlp.label}></Tlp>
+      </Label>
     </div>
-    <ErrorMessage error={loadAdvisoryVersionsError}></ErrorMessage>
-    <ErrorMessage error={stateError}></ErrorMessage>
-    <ErrorMessage error={loadDocumentError}></ErrorMessage>
-    <ErrorMessage error={loadFourCVEsError}></ErrorMessage>
-    <div class="flex flex-row max-[800px]:flex-wrap-reverse">
-      <div class="mr-12 flex w-2/3 flex-col">
-        <div class="flex flex-row">
-          {#if advisoryVersions.length > 0}
-            <Version
-              publisherNamespace={params.publisherNamespace}
-              trackingID={params.trackingID}
-              {advisoryVersions}
-              selectedDocumentVersion={document.tracking?.version}
-              on:selectedDiffDocuments={() => (isDiffOpen = true)}
-              on:disableDiff={() => (isDiffOpen = false)}
-            ></Version>
-          {/if}
-        </div>
-        <div class="flex flex-col min-[800px]:mr-56 min-[1080px]:mr-32">
-          {#if isDiffOpen}
-            <Diff showTitle={false}></Diff>
-          {:else}
-            <Webview
-              basePath={"#/advisories/" +
-                params.publisherNamespace +
-                "/" +
-                params.trackingID +
-                "/documents/" +
-                params.id +
-                "/"}
-              {position}
-            ></Webview>
-          {/if}
-        </div>
+    <div class="flex flex-row flex-wrap items-end justify-start gap-y-2 md:justify-between">
+      <Label class="text-gray-600">{params.publisherNamespace}</Label>
+      <div class="right-6 mt-4 flex h-fit flex-row gap-2 min-[1080px]:absolute">
+        <WorkflowStates {advisoryState} updateStateFn={updateState}></WorkflowStates>
       </div>
-      <div
-        class="right-3 mr-3 flex w-[29rem] flex-col bg-white min-[800px]:ml-auto min-[1080px]:absolute"
-      >
-        <div class={isSSVCediting || commentFocus ? " w-full p-3 shadow-md" : "w-full p-3"}>
-          <div class="mb-4 flex flex-row items-center">
-            {#if ssvcVector}
-              {#if !isSSVCediting}
-                <SsvcBadge vector={ssvcVector}></SsvcBadge>
-              {/if}
+    </div>
+    <div class="mb-4 mt-2" />
+  </div>
+  <ErrorMessage error={loadAdvisoryVersionsError}></ErrorMessage>
+  <ErrorMessage error={stateError}></ErrorMessage>
+  <ErrorMessage error={loadDocumentError}></ErrorMessage>
+  <ErrorMessage error={loadFourCVEsError}></ErrorMessage>
+  <div class="w-full lg:grid lg:grid-cols-[1fr_29rem]">
+    <div
+      class="right-3 mr-3 flex w-[29rem] flex-col bg-white lg:order-2 lg:max-h-full lg:flex-none lg:overflow-auto"
+    >
+      <div class={isSSVCediting || commentFocus ? " w-full p-3 shadow-md" : "w-full p-3"}>
+        <div class="mb-4 flex flex-row items-center">
+          {#if ssvcVector}
+            {#if !isSSVCediting}
+              <SsvcBadge vector={ssvcVector}></SsvcBadge>
             {/if}
-            {#if advisoryState !== ARCHIVED && advisoryState !== DELETE}
-              <SsvcCalculator
-                bind:isEditing={isSSVCediting}
-                vectorInput={ssvcVector}
-                disabled={!isCalculatingAllowed}
-                documentID={params.id}
-                on:updateSSVC={loadMetaData}
-                {allowEditing}
-              ></SsvcCalculator>
-            {/if}
+          {/if}
+          {#if advisoryState !== ARCHIVED && advisoryState !== DELETE}
+            <SsvcCalculator
+              bind:isEditing={isSSVCediting}
+              vectorInput={ssvcVector}
+              disabled={!isCalculatingAllowed}
+              documentID={params.id}
+              on:updateSSVC={loadMetaData}
+              {allowEditing}
+            ></SsvcCalculator>
+          {/if}
+        </div>
+        {#if isCommentingAllowed && !isSSVCediting}
+          <div class="mt-6">
+            <Label class="mb-2" for="comment-textarea"
+              >{advisoryState === ARCHIVED ? "Reactivate with comment" : "New Comment"}</Label
+            >
+            <CommentTextArea
+              on:focus={() => {
+                commentFocus = true;
+              }}
+              on:blur={() => {
+                commentFocus = false;
+              }}
+              on:input={() => (createCommentError = null)}
+              on:saveComment={createComment}
+              on:saveForReview={sendForReview}
+              on:saveForAssessing={sendForAssessing}
+              bind:value={comment}
+              errorMessage={createCommentError}
+              buttonText="Send"
+              state={advisoryState}
+            ></CommentTextArea>
           </div>
-          {#if isCommentingAllowed && !isSSVCediting}
-            <div class="mt-6">
-              <Label class="mb-2" for="comment-textarea"
-                >{advisoryState === ARCHIVED ? "Reactivate with comment" : "New Comment"}</Label
-              >
-              <CommentTextArea
-                on:focus={() => {
-                  commentFocus = true;
-                }}
-                on:blur={() => {
-                  commentFocus = false;
-                }}
-                on:input={() => (createCommentError = null)}
-                on:saveComment={createComment}
-                on:saveForReview={sendForReview}
-                on:saveForAssessing={sendForAssessing}
-                bind:value={comment}
-                errorMessage={createCommentError}
-                buttonText="Send"
-                state={advisoryState}
-              ></CommentTextArea>
-            </div>
-          {/if}
-        </div>
-        <ErrorMessage error={loadDocumentSSVCError}></ErrorMessage>
-        <div class="">
-          {#if appStore.isEditor() || appStore.isReviewer() || appStore.isAuditor()}
-            <div class="mt-6">
-              <History
-                state={advisoryState}
-                on:commentUpdate={() => {
-                  buildHistory();
-                }}
-                entries={historyEntries}
-              ></History>
-            </div>
-            <ErrorMessage error={loadEventsError}></ErrorMessage>
-            <ErrorMessage error={loadCommentsError}></ErrorMessage>
-          {/if}
-        </div>
+        {/if}
+      </div>
+      <ErrorMessage error={loadDocumentSSVCError}></ErrorMessage>
+      <div class="">
+        {#if appStore.isEditor() || appStore.isReviewer() || appStore.isAuditor()}
+          <div class="mt-6">
+            <History
+              state={advisoryState}
+              on:commentUpdate={() => {
+                buildHistory();
+              }}
+              entries={historyEntries}
+            ></History>
+          </div>
+          <ErrorMessage error={loadEventsError}></ErrorMessage>
+          <ErrorMessage error={loadCommentsError}></ErrorMessage>
+        {/if}
+      </div>
+    </div>
+    <div class="mr-12 flex h-auto flex-col lg:order-1 lg:max-h-full lg:flex-auto lg:overflow-auto">
+      <div class="flex flex-row">
+        {#if advisoryVersions.length > 0}
+          <Version
+            publisherNamespace={params.publisherNamespace}
+            trackingID={params.trackingID}
+            {advisoryVersions}
+            selectedDocumentVersion={document.tracking?.version}
+            on:selectedDiffDocuments={() => (isDiffOpen = true)}
+            on:disableDiff={() => (isDiffOpen = false)}
+          ></Version>
+        {/if}
+      </div>
+      <div class="flex flex-col">
+        {#if isDiffOpen}
+          <Diff showTitle={false}></Diff>
+        {:else}
+          <Webview
+            basePath={"#/advisories/" +
+              params.publisherNamespace +
+              "/" +
+              params.trackingID +
+              "/documents/" +
+              params.id +
+              "/"}
+            {position}
+          ></Webview>
+        {/if}
       </div>
     </div>
   </div>

--- a/client/src/lib/Advisories/Advisory.svelte
+++ b/client/src/lib/Advisories/Advisory.svelte
@@ -399,7 +399,9 @@
         {/if}
       </div>
     </div>
-    <div class="mr-12 flex h-auto flex-col lg:order-1 lg:max-h-full lg:flex-auto lg:overflow-auto">
+    <div
+      class="flex h-auto flex-col lg:order-1 lg:max-h-full lg:flex-auto lg:overflow-auto lg:pr-6"
+    >
       <div class="flex flex-row">
         {#if advisoryVersions.length > 0}
           <Version

--- a/client/src/lib/Advisories/CSAFWebview/Collapsible.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/Collapsible.svelte
@@ -73,9 +73,11 @@
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div title={header} id={header} class={class_}>
-    <div on:click={toggle}>
+    <div class="inline-flex items-center" on:click={toggle}>
       <i class="bx {getClass(level)} {icon}" />
-      <span class={getClass(level)}>{header}</span>
+      <slot class={getClass(level)} name="header"
+        ><span class={getClass(level)}>{header}</span></slot
+      >
     </div>
     {#if visibility === "block"}
       <div id={uuid} class={class_}>

--- a/client/src/lib/Advisories/CSAFWebview/Webview.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/Webview.svelte
@@ -56,24 +56,33 @@
     // This is a hack
     setTimeout(() => {
       if (position.startsWith("product-")) {
+        console.log("PRODUCT");
+        updateTabOpen("productTree");
         appStore.setProductTreeSectionVisible();
         appStore.setSelectedProduct(position.replace("product-", ""));
       }
       if (position.startsWith("cve-")) {
+        console.log("CVE");
+        updateTabOpen("vulnerabilities");
         appStore.setSelectedCVE(position.replace("cve-", ""));
         appStore.setVulnerabilitiesSectionVisible();
       }
     }, 300);
   };
 
-  const updateTabOpen = () => {
+  const updateTabOpen = (open?: WebviewDataSections) => {
     let openedTab: WebviewDataSections = (Object.entries(tabOpen).find((tab) => tab[1]) ?? [
       "vulnerabilitiesOverview"
     ])[0] as WebviewDataSections;
-    if (
-      openedTab !== "vulnerabilitiesOverview" &&
-      (screenPhase >= placeToPhase[openedTab].phase || !placeToPhase[openedTab].show)
-    ) {
+    const canBeOpened = (tab: WebviewDataSections) =>
+      tab === "vulnerabilitiesOverview" ||
+      (screenPhase < placeToPhase[tab].phase && placeToPhase[tab].show);
+    if (open && canBeOpened(open)) {
+      if (open !== openedTab) {
+        tabOpen[open] = true;
+        tabOpen[openedTab] = false;
+      }
+    } else if (openedTab !== "vulnerabilitiesOverview" && !canBeOpened(openedTab)) {
       tabOpen.vulnerabilitiesOverview = true;
       tabOpen[openedTab] = false;
     }

--- a/client/src/lib/Advisories/CSAFWebview/Webview.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/Webview.svelte
@@ -154,10 +154,12 @@
         <ValueList label="Aliases" values={aliases} />
       {/if}
       {#if showTab(placeToPhase.revisionHistory)}
-        <Tabs>
+        <Tabs tabStyle="pill">
           <TabItem bind:open={tabOpen.vulnerabilitiesOverview} title="Vulnerabilities overview">
             {#if $appStore.webview.doc?.productVulnerabilities.length > 1}
-              <ProductVulnerabilities {basePath} />
+              <div class={sideScroll}>
+                <ProductVulnerabilities {basePath} />
+              </div>
             {:else}
               <i>
                 <h2>No Vulnerabilities overview</h2>
@@ -167,32 +169,44 @@
           </TabItem>
           {#if showTab(placeToPhase.productTree)}
             <TabItem bind:open={tabOpen.productTree} title="Product tree">
-              <ProductTree {basePath} />
+              <div class={sideScroll}>
+                <ProductTree {basePath} />
+              </div>
             </TabItem>
           {/if}
           {#if showTab(placeToPhase.vulnerabilities)}
             <TabItem bind:open={tabOpen.vulnerabilities} title="Vulnerabilities">
-              <Vulnerabilities {basePath} />
+              <div class={sideScroll}>
+                <Vulnerabilities {basePath} />
+              </div>
             </TabItem>
           {/if}
           {#if showTab(placeToPhase.notes) && $appStore.webview.doc?.notes}
             <TabItem bind:open={tabOpen.notes} title="Notes">
-              <Notes notes={$appStore.webview.doc?.notes} />
+              <div class={sideScroll}>
+                <Notes notes={$appStore.webview.doc?.notes} />
+              </div>
             </TabItem>
           {/if}
           {#if showTab(placeToPhase.acknowledgements) && $appStore.webview.doc?.acknowledgements}
             <TabItem bind:open={tabOpen.acknowledgements} title="Acknowledgements">
-              <Acknowledgements acknowledegements={$appStore.webview.doc?.acknowledgements} />
+              <div class={sideScroll}>
+                <Acknowledgements acknowledegements={$appStore.webview.doc?.acknowledgements} />
+              </div>
             </TabItem>
           {/if}
           {#if showTab(placeToPhase.references)}
             <TabItem bind:open={tabOpen.references} title="References">
-              <References references={$appStore.webview.doc?.references} />
+              <div class={sideScroll}>
+                <References references={$appStore.webview.doc?.references} />
+              </div>
             </TabItem>
           {/if}
           {#if showTab(placeToPhase.revisionHistory)}
             <TabItem bind:open={tabOpen.revisionHistory} title="Revision history">
-              <RevisionHistory />
+              <div class={sideScroll}>
+                <RevisionHistory />
+              </div>
             </TabItem>
           {/if}
         </Tabs>

--- a/client/src/lib/Advisories/CSAFWebview/Webview.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/Webview.svelte
@@ -130,7 +130,7 @@
   $: innerWidth = 0;
   $: {
     let oldPhase = screenPhase;
-    screenPhase = Math.max(0, Math.floor(innerWidth / 480 - 2));
+    screenPhase = Math.max(0, Math.floor(innerWidth / 550 - 2));
     if (oldPhase !== screenPhase) {
       updatePlaces();
     }
@@ -151,7 +151,7 @@
 
 <svelte:window bind:innerWidth />
 
-<div class="grid auto-cols-fr grid-flow-col gap-10">
+<div class="grid auto-cols-fr grid-flow-col gap-6">
   {#if isCSAF}
     <div class="flex w-full flex-col">
       {#if $appStore.webview.doc}

--- a/client/src/lib/Advisories/CSAFWebview/Webview.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/Webview.svelte
@@ -242,40 +242,40 @@
         </div>
       </div>
     {/if}
-  {/if}
-  {#if showArea(placeToPhase.notes) && $appStore.webview.doc?.notes}
-    <div>
-      <span class="text-xl">Notes</span>
-      <div class={sideScroll}>
-        <Notes notes={$appStore.webview.doc?.notes} />
+    {#if showArea(placeToPhase.notes) && $appStore.webview.doc?.notes}
+      <div>
+        <span class="text-xl">Notes</span>
+        <div class={sideScroll}>
+          <Notes notes={$appStore.webview.doc?.notes} />
+        </div>
       </div>
-    </div>
-  {/if}
+    {/if}
 
-  {#if showArea(placeToPhase.acknowledgements) && $appStore.webview.doc?.acknowledgements}
-    <div>
-      <span class="text-xl">Acknowledgements</span>
-      <div class={sideScroll}>
-        <Acknowledgements acknowledegements={$appStore.webview.doc?.acknowledgements} />
+    {#if showArea(placeToPhase.acknowledgements) && $appStore.webview.doc?.acknowledgements}
+      <div>
+        <span class="text-xl">Acknowledgements</span>
+        <div class={sideScroll}>
+          <Acknowledgements acknowledegements={$appStore.webview.doc?.acknowledgements} />
+        </div>
       </div>
-    </div>
-  {/if}
+    {/if}
 
-  {#if showArea(placeToPhase.references)}
-    <div>
-      <span class="text-xl">References</span>
-      <div class={sideScroll}>
-        <References references={$appStore.webview.doc?.references} />
+    {#if showArea(placeToPhase.references)}
+      <div>
+        <span class="text-xl">References</span>
+        <div class={sideScroll}>
+          <References references={$appStore.webview.doc?.references} />
+        </div>
       </div>
-    </div>
-  {/if}
+    {/if}
 
-  {#if showArea(placeToPhase.revisionHistory)}
-    <div>
-      <span class="text-xl">Revision history</span>
-      <div class={sideScroll}>
-        <RevisionHistory />
+    {#if showArea(placeToPhase.revisionHistory)}
+      <div>
+        <span class="text-xl">Revision history</span>
+        <div class={sideScroll}>
+          <RevisionHistory />
+        </div>
       </div>
-    </div>
+    {/if}
   {/if}
 </div>

--- a/client/src/lib/Advisories/CSAFWebview/general/General.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/general/General.svelte
@@ -42,7 +42,7 @@
   const cellStyleKey = "w-40 py-0";
 </script>
 
-<div class="2xl:w-max">
+<div class="w-full">
   <div class="mb-3">
     <span class="text-xl">{title} </span>
     {#if $appStore.webview.doc?.status !== Status.final}

--- a/client/src/lib/Advisories/CSAFWebview/general/RevisionHistory.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/general/RevisionHistory.svelte
@@ -19,24 +19,25 @@
     TableHeadCell
   } from "flowbite-svelte";
   import { tablePadding } from "$lib/Table/defaults";
-  const cellStyle = "whitespace-nowrap py-0 px-2";
+  const baseCellStyle = "py-0 px-2";
+  const cellStyle = "whitespace-nowrap " + baseCellStyle;
 </script>
 
 {#if $appStore.webview.doc?.isRevisionHistoryPresent}
   <div class="mt-1 w-fit pl-5">
-    <Table noborder>
+    <Table noborder striped={true}>
       <TableHead>
-        <TableHeadCell padding={tablePadding}>Date</TableHeadCell>
         <TableHeadCell padding={tablePadding}>Number</TableHeadCell>
+        <TableHeadCell padding={tablePadding}>Date</TableHeadCell>
         <TableHeadCell padding={tablePadding}>Summary</TableHeadCell>
         <TableHeadCell padding={tablePadding}>Legacy_version</TableHeadCell>
       </TableHead>
       <TableBody>
         {#each $appStore.webview.doc?.revisionHistory as entry}
           <TableBodyRow>
-            <TableBodyCell tdClass={cellStyle}>{entry.date}</TableBodyCell>
             <TableBodyCell tdClass={cellStyle}>{entry.number}</TableBodyCell>
-            <TableBodyCell tdClass={cellStyle}>{entry.summary}</TableBodyCell>
+            <TableBodyCell tdClass={cellStyle}>{entry.date}</TableBodyCell>
+            <TableBodyCell tdClass={baseCellStyle + " min-w-52"}>{entry.summary}</TableBodyCell>
             <TableBodyCell
               >{#if entry.legacyVersion}{entry.legacyVersion}{/if}</TableBodyCell
             >

--- a/client/src/lib/Advisories/CSAFWebview/producttree/ProductTree.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/producttree/ProductTree.svelte
@@ -19,20 +19,29 @@
 </script>
 
 {#if $appStore.webview.doc?.productTree.branches}
-  {#each $appStore.webview.doc?.productTree.branches as branch}
-    <Collapsible
-      header="Branches"
-      open={$appStore.webview.ui.isProductTreeVisible ||
-        ($appStore.webview.ui.isProductTreeOpen &&
-          !(
-            $appStore.webview.doc?.productTree.relationships &&
-            $appStore.webview.doc?.productTree.product_groups &&
-            $appStore.webview.doc?.productTree.full_product_names
-          ))}
-    >
-      <Branch {branch} />
-    </Collapsible>
-  {/each}
+  <Collapsible
+    header="Branches"
+    open={$appStore.webview.ui.isProductTreeVisible ||
+      ($appStore.webview.ui.isProductTreeOpen &&
+        !(
+          $appStore.webview.doc?.productTree.relationships &&
+          $appStore.webview.doc?.productTree.product_groups &&
+          $appStore.webview.doc?.productTree.full_product_names
+        ))}
+  >
+    {#each $appStore.webview.doc?.productTree.branches as branch}
+      <Branch
+        {branch}
+        open={$appStore.webview.ui.isProductTreeVisible ||
+          ($appStore.webview.ui.isProductTreeOpen &&
+            !(
+              $appStore.webview.doc?.productTree.relationships &&
+              $appStore.webview.doc?.productTree.product_groups &&
+              $appStore.webview.doc?.productTree.full_product_names
+            ))}
+      />
+    {/each}
+  </Collapsible>
 {/if}
 
 {#if $appStore.webview.doc?.productTree.relationships}

--- a/client/src/lib/Advisories/CSAFWebview/producttree/branch/Branch.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/producttree/branch/Branch.svelte
@@ -9,24 +9,27 @@
 -->
 
 <script lang="ts">
-  import BranchComponent from "./Branch.svelte";
+  import Collapsible from "$lib/Advisories/CSAFWebview/Collapsible.svelte";
   import Product from "$lib/Advisories/CSAFWebview/producttree/product/Product.svelte";
   import type { Branch } from "$lib/types";
   import { Badge } from "flowbite-svelte";
   export let branch: Branch;
+  export let open: boolean;
 </script>
 
 <div class="pl-3">
-  <div class="py-2">
-    <Badge rounded large color="dark">{branch.category}</Badge>
-    {branch.name}
-  </div>
-  {#if branch.branches}
-    {#each branch.branches as b}
-      <BranchComponent branch={b} />
-    {/each}
-  {/if}
-  {#if branch.product}
-    <Product product={branch.product} />
-  {/if}
+  <Collapsible {open} header={branch.category + ": " + branch.name}>
+    <div slot="header" class="py-2">
+      <Badge rounded large color="dark">{branch.category}</Badge>
+      {branch.name}
+    </div>
+    {#if branch.branches}
+      {#each branch.branches as b}
+        <svelte:self branch={b} {open} />
+      {/each}
+    {/if}
+    {#if branch.product}
+      <Product product={branch.product} />
+    {/if}
+  </Collapsible>
 </div>

--- a/client/src/lib/Advisories/CSAFWebview/productvulnerabilities/ProductVulnerabilities.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/productvulnerabilities/ProductVulnerabilities.svelte
@@ -144,19 +144,19 @@
             <TableBodyRow>
               {#each line as column}
                 {#if column.name === "Product"}
-                  <TableBodyCell tdClass={tdClass + " sticky left-0 bg-inherit"}
-                    ><a
-                      title={$appStore.webview.doc?.productsByID[column.content]}
-                      id={crypto.randomUUID()}
-                      href={basePath + "product-" + encodeURIComponent(column.content)}
-                      >{$appStore.webview.doc?.productsByID[column.content].length > 20
-                        ? `${$appStore.webview.doc?.productsByID[column.content].substring(0, 20)}...`
-                        : `${$appStore.webview.doc?.productsByID[column.content]}`}
-                      ({column.content.length > 20
-                        ? column.content.substring(0, 20)
-                        : column.content})</a
-                    ></TableBodyCell
-                  >
+                  <TableBodyCell tdClass={tdClass + " sticky left-0 bg-inherit"}>
+                    <div class="max-w-1/2 min-w-56 whitespace-normal text-wrap">
+                      <a
+                        title={$appStore.webview.doc?.productsByID[column.content]}
+                        id={crypto.randomUUID()}
+                        href={basePath + "product-" + encodeURIComponent(column.content)}
+                        >{$appStore.webview.doc?.productsByID[column.content]}
+                        ({column.content.length > 20
+                          ? column.content.substring(0, 20) + "..."
+                          : column.content})</a
+                      >
+                    </div>
+                  </TableBodyCell>
                 {:else if column.content === "N.A" && ((!renderAllCVEs && fourCVEs.includes(column.name)) || column.name === "Total")}
                   <TableBodyCell {tdClass}>{column.content}</TableBodyCell>
                 {:else if column.content === "N.A" && renderAllCVEs && (fourCVEs.includes(column.name) || column.name === "Total")}

--- a/client/src/lib/Advisories/CSAFWebview/productvulnerabilities/ProductVulnerabilities.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/productvulnerabilities/ProductVulnerabilities.svelte
@@ -96,20 +96,20 @@
               >
             {:else if index == 1}
               <TableHeadCell class="text-nowrap font-normal" padding={tablePadding}>
-                <div class={!renderAllCVEs ? "" : titleStyles[0]}>
-                  <div class={!renderAllCVEs ? "" : titleStyles[1]}>
-                    <div class={!renderAllCVEs ? "" : titleStyles[2]}>
-                      <div class={!renderAllCVEs ? "" : titleStyles[3]}>{column.content}</div>
+                <div class={titleStyles[0]}>
+                  <div class={titleStyles[1]}>
+                    <div class={titleStyles[2]}>
+                      <div class={titleStyles[3]}>{column.content}</div>
                     </div>
                   </div>
                 </div>
               </TableHeadCell>
             {:else if !renderAllCVEs && fourCVEs.includes(column.name)}
               <TableHeadCell class="text-nowrap font-normal" padding={tablePadding}>
-                <div class={!renderAllCVEs ? "" : titleStyles[0]}>
-                  <div class={!renderAllCVEs ? "" : titleStyles[1]}>
-                    <div class={!renderAllCVEs ? "" : titleStyles[2]}>
-                      <div class={!renderAllCVEs ? "" : titleStyles[3]}>
+                <div class={titleStyles[0]}>
+                  <div class={titleStyles[1]}>
+                    <div class={titleStyles[2]}>
+                      <div class={titleStyles[3]}>
                         <a
                           id={crypto.randomUUID()}
                           href={basePath + "cve-" + encodeURIComponent(column.content)}
@@ -122,10 +122,10 @@
               </TableHeadCell>
             {:else if renderAllCVEs}
               <TableHeadCell class="text-nowrap font-normal" padding={tablePadding}>
-                <div class={!renderAllCVEs ? "" : titleStyles[0]}>
-                  <div class={!renderAllCVEs ? "" : titleStyles[1]}>
-                    <div class={!renderAllCVEs ? "" : titleStyles[2]}>
-                      <div class={!renderAllCVEs ? "" : titleStyles[3]}>
+                <div class={titleStyles[0]}>
+                  <div class={titleStyles[1]}>
+                    <div class={titleStyles[2]}>
+                      <div class={titleStyles[3]}>
                         <a
                           id={crypto.randomUUID()}
                           href={basePath + "cve-" + encodeURIComponent(column.content)}

--- a/client/src/lib/Advisories/CSAFWebview/productvulnerabilities/ProductVulnerabilities.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/productvulnerabilities/ProductVulnerabilities.svelte
@@ -27,6 +27,13 @@
   let headerColumns: any[] = [];
   let productLines: any[] = [];
 
+  const titleStyles = [
+    "w-4 overflow-hidden",
+    "w-max",
+    "[padding:50%_0] h-0",
+    "origin-top-left -rotate-90 mt-[50%] -translate-full whitespace-nowrap block"
+  ];
+
   export let basePath = "";
 
   onMount(() => {
@@ -47,7 +54,7 @@
 <div class="crosstable-overview mb-3 mt-3 flex flex-col">
   {#if productLines.length > 0}
     <div class="mb-3 mt-3 flex flex-row">
-      <div class="flex flex-row items-baseline gap-4">
+      <div class="flex flex-wrap items-baseline gap-4">
         <div class="flex flex-row items-baseline">
           <i class="bx bx-check" />
           <span class="ml-1 text-nowrap">Fixed</span>
@@ -65,7 +72,7 @@
           <i class="bx bx-heart" /><span class="ml-1 text-nowrap">Recommended</span>
         </div>
         {#if productLines[0].length > 6}
-          <div class="flex flex-row items-baseline">
+          <div class="ml-auto flex flex-row items-baseline">
             <Button
               color="light"
               size="sm"
@@ -83,27 +90,52 @@
         <TableHead>
           {#each headerColumns as column, index}
             {#if index == 0}
-              <TableHeadCell class="text-nowrap font-normal" padding={tablePadding}
-                >{column.content}</TableHeadCell
+              <TableHeadCell
+                class="sticky left-0 z-30 text-nowrap bg-white align-bottom font-normal"
+                padding={tablePadding}>{column.content}</TableHeadCell
               >
             {:else if index == 1}
-              <TableHeadCell class="text-nowrap font-normal" padding={tablePadding}
-                >{column.content}</TableHeadCell
-              >
+              <TableHeadCell class="text-nowrap font-normal" padding={tablePadding}>
+                <div class={!renderAllCVEs ? "" : titleStyles[0]}>
+                  <div class={!renderAllCVEs ? "" : titleStyles[1]}>
+                    <div class={!renderAllCVEs ? "" : titleStyles[2]}>
+                      <div class={!renderAllCVEs ? "" : titleStyles[3]}>{column.content}</div>
+                    </div>
+                  </div>
+                </div>
+              </TableHeadCell>
             {:else if !renderAllCVEs && fourCVEs.includes(column.name)}
-              <TableHeadCell class="text-nowrap font-normal" padding={tablePadding}
-                ><a
-                  id={crypto.randomUUID()}
-                  href={basePath + "cve-" + encodeURIComponent(column.content)}>{column.content}</a
-                ></TableHeadCell
-              >
+              <TableHeadCell class="text-nowrap font-normal" padding={tablePadding}>
+                <div class={!renderAllCVEs ? "" : titleStyles[0]}>
+                  <div class={!renderAllCVEs ? "" : titleStyles[1]}>
+                    <div class={!renderAllCVEs ? "" : titleStyles[2]}>
+                      <div class={!renderAllCVEs ? "" : titleStyles[3]}>
+                        <a
+                          id={crypto.randomUUID()}
+                          href={basePath + "cve-" + encodeURIComponent(column.content)}
+                          >{column.content}</a
+                        >
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </TableHeadCell>
             {:else if renderAllCVEs}
-              <TableHeadCell class="text-nowrap font-normal" padding={tablePadding}
-                ><a
-                  id={crypto.randomUUID()}
-                  href={basePath + "cve-" + encodeURIComponent(column.content)}>{column.content}</a
-                ></TableHeadCell
-              >
+              <TableHeadCell class="text-nowrap font-normal" padding={tablePadding}>
+                <div class={!renderAllCVEs ? "" : titleStyles[0]}>
+                  <div class={!renderAllCVEs ? "" : titleStyles[1]}>
+                    <div class={!renderAllCVEs ? "" : titleStyles[2]}>
+                      <div class={!renderAllCVEs ? "" : titleStyles[3]}>
+                        <a
+                          id={crypto.randomUUID()}
+                          href={basePath + "cve-" + encodeURIComponent(column.content)}
+                          >{column.content}
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </TableHeadCell>
             {/if}
           {/each}
         </TableHead>
@@ -112,7 +144,7 @@
             <TableBodyRow>
               {#each line as column}
                 {#if column.name === "Product"}
-                  <TableBodyCell {tdClass}
+                  <TableBodyCell tdClass={tdClass + " sticky left-0 bg-inherit"}
                     ><a
                       title={$appStore.webview.doc?.productsByID[column.content]}
                       id={crypto.randomUUID()}

--- a/client/src/lib/Advisories/History.svelte/History.svelte
+++ b/client/src/lib/Advisories/History.svelte/History.svelte
@@ -32,7 +32,7 @@
       });
 </script>
 
-<div class="flex max-h-[34rem] flex-col overflow-auto p-1">
+<div class="flex max-h-[470px] flex-col overflow-auto p-1">
   <Table>
     <TableBody>
       {#each historyEntries as event}


### PR DESCRIPTION
Closes #177 

See commit messages for what has been done and why.
Further TODOs both from the issue and from further deliberations with @bernhardreiter have been moved to new issue #488
They can be handled separately.

For further info:
Had to implement splitting off the sections from the tab on bigger screen sizes via script, since dynamically removing tabs from a tab group  while automatically jumping to the one that is still left, is simply not possible with pure css.