### PR TITLE
Endpoints for import stats

### DIFF
--- a/pkg/web/controller.go
+++ b/pkg/web/controller.go
@@ -171,5 +171,10 @@ func (c *Controller) Bind() http.Handler {
 	api.DELETE("/sources/feeds/:id", authSM, c.deleteFeed)
 	api.GET("/sources/feeds/:id/log", authSM, c.feedLog)
 
+	// Import stats
+	api.GET("/stats/imports/source/:id", authAll, c.importStatsSource)
+	api.GET("/stats/imports/feed/:id", authAll, c.importStatsFeed)
+	api.GET("/stats/imports", authAll, c.importStatsAllSources)
+
 	return r
 }

--- a/pkg/web/importstats.go
+++ b/pkg/web/importstats.go
@@ -62,8 +62,6 @@ func (c *Controller) importStatsSource(ctx *gin.Context) {
 		return
 	}
 	ctx.JSON(http.StatusOK, list)
-	// TODO: Implement me!
-	ctx.JSON(http.StatusNotFound, gin.H{"error": "not implemented, yet"})
 }
 
 func (c *Controller) importStatsAllSources(ctx *gin.Context) {

--- a/pkg/web/importstats.go
+++ b/pkg/web/importstats.go
@@ -1,0 +1,212 @@
+// This file is Free Software under the Apache-2.0 License
+// without warranty, see README.md and LICENSES/Apache-2.0.txt for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: 2024 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+// Software-Engineering: 2024 Intevation GmbH <https://intevation.de>
+
+package web
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const selectImportStatsSQL = `SELECT ` +
+	`date_bin($1, time, $2) AS bucket,` +
+	`count(*) AS count ` +
+	`FROM downloads %s ` +
+	`WHERE time BETWEEN $2 AND $3 %s ` +
+	`GROUP BY bucket ` +
+	`ORDER BY bucket`
+
+func (c *Controller) importStatsSource(ctx *gin.Context) {
+	sourcesID, ok := parse(ctx, toInt64, ctx.Param("id"))
+	if !ok {
+		return
+	}
+	from, to, step, ok := importStatsInterval(ctx)
+	if !ok {
+		return
+	}
+	var cond strings.Builder
+	cond.WriteString(`AND feeds.sources_id = $4`)
+	if !filterImportStats(ctx, &cond) {
+		return
+	}
+	var list [][]any
+	if err := c.db.Run(
+		ctx.Request.Context(),
+		func(rctx context.Context, conn *pgxpool.Conn) error {
+			const joinFeeds = `JOIN feeds ON downloads.feeds_id = feeds.id`
+			sql := fmt.Sprintf(selectImportStatsSQL, joinFeeds, cond.String())
+			rows, _ := conn.Query(rctx, sql, step, from, to, sourcesID)
+			var err error
+			list, err = collectBuckets(rows)
+			return err
+		}, 0,
+	); err != nil {
+		slog.Error("Cannot fetch import stats", "error", err)
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	ctx.JSON(http.StatusOK, list)
+	// TODO: Implement me!
+	ctx.JSON(http.StatusNotFound, gin.H{"error": "not implemented, yet"})
+}
+
+func (c *Controller) importStatsAllSources(ctx *gin.Context) {
+	from, to, step, ok := importStatsInterval(ctx)
+	if !ok {
+		return
+	}
+	var cond strings.Builder
+	if !filterImportStats(ctx, &cond) {
+		return
+	}
+	var list [][]any
+	if err := c.db.Run(
+		ctx.Request.Context(),
+		func(rctx context.Context, conn *pgxpool.Conn) error {
+			sql := fmt.Sprintf(selectImportStatsSQL, "", cond.String())
+			rows, _ := conn.Query(rctx, sql, step, from, to)
+			var err error
+			list, err = collectBuckets(rows)
+			return err
+		}, 0,
+	); err != nil {
+		slog.Error("Cannot fetch import stats", "error", err)
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	ctx.JSON(http.StatusOK, list)
+}
+
+func (c *Controller) importStatsFeed(ctx *gin.Context) {
+	feedID, ok := parse(ctx, toInt64, ctx.Param("id"))
+	if !ok {
+		return
+	}
+	from, to, step, ok := importStatsInterval(ctx)
+	if !ok {
+		return
+	}
+	var cond strings.Builder
+	cond.WriteString(`AND feeds_id = $4`)
+	if !filterImportStats(ctx, &cond) {
+		return
+	}
+	var list [][]any
+	if err := c.db.Run(
+		ctx.Request.Context(),
+		func(rctx context.Context, conn *pgxpool.Conn) error {
+			sql := fmt.Sprintf(selectImportStatsSQL, "", cond.String())
+			rows, _ := conn.Query(rctx, sql, step, from, to, feedID)
+			var err error
+			list, err = collectBuckets(rows)
+			return err
+		}, 0,
+	); err != nil {
+		slog.Error("Cannot fetch import stats", "error", err)
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	ctx.JSON(http.StatusOK, list)
+}
+
+func collectBuckets(rows pgx.Rows) ([][]any, error) {
+	return pgx.CollectRows(rows,
+		func(row pgx.CollectableRow) ([]any, error) {
+			var bucket time.Time
+			var count int64
+			if err := row.Scan(&bucket, &count); err != nil {
+				return nil, err
+			}
+			return []any{bucket.UTC(), count}, nil
+		})
+}
+
+func importStatsInterval(ctx *gin.Context) (time.Time, time.Time, time.Duration, bool) {
+	var (
+		ok       bool
+		from, to time.Time
+		step     time.Duration
+		now      = sync.OnceValue(time.Now)
+	)
+	if value := ctx.Query("from"); value != "" {
+		if from, ok = parse(ctx, parseTime, value); !ok {
+			return time.Time{}, time.Time{}, 0, false
+		}
+	} else {
+		from = now().Add(-time.Hour * 3 * 24)
+	}
+
+	if value := ctx.Query("to"); value != "" {
+		if to, ok = parse(ctx, parseTime, value); !ok {
+			return time.Time{}, time.Time{}, 0, false
+		}
+	} else {
+		to = now()
+	}
+
+	if to.Before(from) {
+		to, from = from, to
+	}
+
+	if value := ctx.Query("step"); value != "" {
+		if step, ok = parse(ctx, time.ParseDuration, value); !ok {
+			return time.Time{}, time.Time{}, 0, false
+		}
+		step = step.Abs()
+	} else {
+		step = to.Sub(from)
+	}
+	return from.UTC(), to.UTC(), step, true
+}
+
+func filterImportStats(ctx *gin.Context, cond *strings.Builder) bool {
+	have := false
+	for _, flag := range []string{
+		"download_failed",
+		"filename_failed",
+		"schema_failed",
+		"remote_failed",
+		"checksum_failed",
+		"signature_failed",
+	} {
+		if value := ctx.Query(flag); value != "" {
+			v, ok := parse(ctx, strconv.ParseBool, value)
+			if !ok {
+				return false
+			}
+			if have {
+				cond.WriteString(" OR ")
+			} else {
+				have = true
+				if cond.Len() > 0 {
+					cond.WriteString(" AND ")
+				}
+				cond.WriteByte('(')
+			}
+			if !v {
+				cond.WriteString("NOT ")
+			}
+			cond.WriteString(flag)
+		}
+	}
+	if have {
+		cond.WriteByte(')')
+	}
+	return true
+}

--- a/pkg/web/util.go
+++ b/pkg/web/util.go
@@ -9,12 +9,28 @@
 package web
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/ISDuBA/ISDuBA/pkg/database/query"
 	"github.com/gin-gonic/gin"
 )
+
+// parseTime parses a time from a given string.
+func parseTime(s string) (time.Time, error) {
+	for _, layout := range []string{
+		time.RFC3339,
+		time.DateTime,
+		time.DateOnly,
+	} {
+		if v, err := time.Parse(layout, s); err == nil {
+			return v, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("cannot parse %q as time", s)
+}
 
 // parserMode parses parser mode from a given string.
 func parserMode(s string) (query.ParserMode, error) {


### PR DESCRIPTION
This PR adds three new endpoints to the server:

1 - `GET /stats/imports/source/:id`
2 - `GET /stats/imports/feed/:id`
3 - `GET /stats/imports`

1 returns a list of accumulated imports for a source of given id. 2 does the same for a given feed. 3 for all sources.

The accumulation is parameterized with the query parameters `from`, `to` and `step`.
`from` and `to` are timestamps. Accepted formats  are `time.RFC3339`, `time.DateTime` and `time.DateOnly`
`step` is parsed as `time.Duration`. `from` defaults to now minus 3 days, `to` to now and `step` is the whole interval.

Special conditions are supported with the boolean query parameters `download_failed`, `filename_failed`, `schema_failed`, `remote_failed`, `checksum_failed` and `signature_failed`. By default all imports are returned.

Example usage against my system:
```
curl -s -D /dev/stderr --get \ 
-H "Authorization: Bearer $TOKEN" \
--data-urlencode 'from=2024-01-02' \
--data-urlencode 'to=2024-10-11' \
--data-urlencode 'step=24h' \
--data-urlencode 'download_failed=false' \
http://localhost:8081/api/stats/imports/source/7 | jq .
```
results in:
```
[
  [
    "2024-09-19T00:00:00Z",
    501
  ],
  [
    "2024-09-23T00:00:00Z",
    4912
  ],
  [
    "2024-09-24T00:00:00Z",
    2300
  ],
  [
    "2024-10-10T00:00:00Z",
    6724
  ]
]
```

which is a list of two-element lists. The first items in the two-element lists are the start timestamp of a interval step. The second is the number of imports in this interval.