### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,13 @@ updates:
     schedule:
       interval: "weekly"
     labels: [ ]
+    groups:
+      dependencies:
+        update-types:
+        - "minor"
+        - "patch"
+        exclude-patterns:
+        - "flowbite*"
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:


### PR DESCRIPTION
It is possible to group dependencies so a single PR will be created for multiple dependencies (https://github.blog/news-insights/product-news/a-faster-way-to-manage-version-updates-with-dependabot/). This PR will make testing more efficient as it is not necessary to checkout a branch for each dependency to start testing it.

I would start by grouping minor releases as they usually don't contain breaking changes but I would exclude Flowbite 'cause it's in alpha currently and we often have to adjust things when updating it.

@koplas, @JanHoefelmeyer what do you think?