### PR TITLE
Fix source header parsing

### DIFF
--- a/client/src/lib/Sources/SourceCreator.svelte
+++ b/client/src/lib/Sources/SourceCreator.svelte
@@ -123,6 +123,10 @@
     }
   };
 
+  const inputChange = async () => {
+    await updateSourceForm();
+  };
+
   onMount(async () => {
     await loadSourceDefaults();
     let domain = params?.domain;
@@ -168,7 +172,7 @@
       {/if}
     </List>
 
-    <SourceForm bind:this={sourceForm} {formClass} {source}></SourceForm>
+    <SourceForm bind:this={sourceForm} {inputChange} {formClass} {source}></SourceForm>
     <FeedView feeds={pmdFeeds}></FeedView>
 
     <Button on:click={saveAll} color="light">

--- a/client/src/lib/Sources/SourceEditor.svelte
+++ b/client/src/lib/Sources/SourceEditor.svelte
@@ -58,6 +58,8 @@
   let updateSourceForm: any;
   let fillAgeDataFromSource: (source: Source) => void;
 
+  let loadSource: boolean = true;
+
   let source: Source = {
     name: "",
     url: "",
@@ -96,6 +98,7 @@
     let result = await fetchSource(Number(id), true);
     if (result.ok) {
       source = result.value;
+      loadSource = true;
       if (fillAgeDataFromSource) {
         fillAgeDataFromSource(source);
       }
@@ -342,7 +345,13 @@
       Loading source configuration ...
       <Spinner color="gray" size="4"></Spinner>
     </div>
-    <SourceForm bind:this={sourceForm} {inputChange} {source} {formClass} enableActive={true}
+    <SourceForm
+      bind:this={sourceForm}
+      bind:parseSource={loadSource}
+      {inputChange}
+      {source}
+      {formClass}
+      enableActive={true}
     ></SourceForm>
     <Button disabled={!sourceEdited} on:click={updateSource} color="light">
       <i class="bx bxs-save me-2"></i>

--- a/client/src/lib/Sources/SourceForm.svelte
+++ b/client/src/lib/Sources/SourceForm.svelte
@@ -24,6 +24,7 @@
   export let formClass: string = "";
   export let source: Source;
   export let enableActive: boolean = false;
+  export let parseSource: boolean = true;
   export const updateSource = async () => {
     formatHeaders();
     await loadCerts();
@@ -142,16 +143,12 @@
   };
 
   const onChangedHeaders = (e: Event | undefined) => {
-    const lastIndex = headers.length - 1;
-    if (
-      (headers[lastIndex][0].length > 0 && headers[lastIndex][1].length > 0) ||
-      (lastIndex - 1 >= 0 &&
-        headers[lastIndex - 1][0].length > 0 &&
-        headers[lastIndex - 1][1].length > 0)
-    ) {
+    let lastElement = headers[headers.length - 1];
+    if (lastElement === undefined || (lastElement[0] !== "" && lastElement[1] !== "")) {
       headers.push(["", ""]);
-      headers = headers;
     }
+    formatHeaders();
+
     if (e) {
       inputChange();
     }
@@ -181,7 +178,10 @@
   };
 
   $: if (source.headers) {
-    parseHeaders();
+    if (parseSource) {
+      parseHeaders();
+      parseSource = false;
+    }
   }
 
   const parseHeaders = () => {


### PR DESCRIPTION
The header field will currently reset in the SourceCreator if another field is edited. This pull request prevents this effect.