### PR TITLE
Fix: Clone default queries in opposite order since the first cloned will be the last in order after cloning

### DIFF
--- a/client/src/lib/Queries/Overview.svelte
+++ b/client/src/lib/Queries/Overview.svelte
@@ -101,7 +101,7 @@
     let failed = false;
     isCloning = true;
     // Clone the special queries
-    for (let i = globalRelevantQueries.length-1; i >= 0; i--) {
+    for (let i = globalRelevantQueries.length - 1; i >= 0; i--) {
       const queryToClone = globalRelevantQueries[i];
       if (queryToClone) {
         queryToClone.global = false;

--- a/client/src/lib/Queries/Overview.svelte
+++ b/client/src/lib/Queries/Overview.svelte
@@ -101,7 +101,7 @@
     let failed = false;
     isCloning = true;
     // Clone the special queries
-    for (let i = 0; i < globalRelevantQueries.length; i++) {
+    for (let i = globalRelevantQueries.length-1; i >= 0; i--) {
       const queryToClone = globalRelevantQueries[i];
       if (queryToClone) {
         queryToClone.global = false;


### PR DESCRIPTION
Second half of https://github.com/ISDuBA/ISDuBA/issues/507