### PR TITLE
feat: Show comments in event table

### DIFF
--- a/client/src/lib/Queries/query.ts
+++ b/client/src/lib/Queries/query.ts
@@ -112,6 +112,12 @@ const SEARCHPAGECOLUMNS = {
     "comments"
   ],
   EVENT: [
+    "time",
+    "event",
+    "actor",
+    "comments",
+    "event_state",
+    "comments_id",
     "critical",
     "id",
     "tracking_id",
@@ -124,13 +130,7 @@ const SEARCHPAGECOLUMNS = {
     "cvss_v2_score",
     "cvss_v3_score",
     "ssvc",
-    "four_cves",
-    "comments",
-    "event",
-    "event_state",
-    "time",
-    "actor",
-    "comments_id"
+    "four_cves"
   ]
 };
 interface Column {

--- a/client/src/lib/Search/Overview.svelte
+++ b/client/src/lib/Search/Overview.svelte
@@ -190,6 +190,7 @@
         on:click={() => {
           query.queryType = SEARCHTYPES.EVENT;
           query.columns = SEARCHPAGECOLUMNS.EVENT;
+          query.orders = ["-time"];
           clearSearch();
         }}>Events</Button
       >

--- a/client/src/lib/Table/Table.svelte
+++ b/client/src/lib/Table/Table.svelte
@@ -85,6 +85,8 @@
   $: isMultiSelectionAllowed =
     isRoleIncluded(appStore.getRoles(), [EDITOR, IMPORTER, ADMIN, REVIEWER]) &&
     ((tableType !== SEARCHTYPES.EVENT && appStore.isAdmin()) || tableType === SEARCHTYPES.ADVISORY);
+  $: areThereAnyComments =
+    tableType === SEARCHTYPES.EVENT && documents?.find((d: any) => d.event === "add_comment");
 
   let selectedState: any;
   let dropdownOpen = false;
@@ -506,6 +508,9 @@
               </TableHeadCell>
             {/if}
             <TableHeadCell padding="px-0"></TableHeadCell>
+            {#if areThereAnyComments}
+              <TableHeadCell padding={tablePadding} class="cursor-default">Comment</TableHeadCell>
+            {/if}
             {#each columns as column}
               {#if column !== searchColumnName}
                 <TableHeadCell
@@ -600,6 +605,23 @@
                     </button>
                   </div>
                 </TableBodyCell>
+                {#if areThereAnyComments}
+                  <TableBodyCell {tdClass}>
+                    {#if item.comments_id}
+                      {#await request(`api/comments/post/${item.comments_id}`, "GET")}
+                        <Spinner color="gray" size="4"></Spinner>
+                      {:then response}
+                        {#if response.ok}
+                          <div class="w-[120pt] max-w-[140pt] text-wrap">
+                            {response.content.message}
+                          </div>
+                        {:else}
+                          <span class="text-red-700">Couldn't load comment.</span>
+                        {/if}
+                      {/await}
+                    {/if}
+                  </TableBodyCell>
+                {/if}
                 {#each columns as column}
                   {#if column !== searchColumnName}
                     {#if column === "cvss_v3_score" || column === "cvss_v2_score"}


### PR DESCRIPTION
Show comments in event table. Also, re-order columns because in an event table the information of the event itself are more important. Additionally, order events by time by default because users probably are more interested in what happend recently.

Solves #512.