### PR TITLE
Endpoint for critical stats

### DIFF
--- a/pkg/web/controller.go
+++ b/pkg/web/controller.go
@@ -178,6 +178,9 @@ func (c *Controller) Bind() http.Handler {
 	api.GET("/stats/cve/source/:id", authAll, c.cveStatsSource)
 	api.GET("/stats/cve/feed/:id", authAll, c.cveStatsFeed)
 	api.GET("/stats/cve", authAll, c.cveStatsAllSources)
+	api.GET("/stats/critical/source/:id", authAll, c.criticalStatsSource)
+	api.GET("/stats/critical/feed/:id", authAll, c.criticalStatsFeed)
+	api.GET("/stats/critical", authAll, c.criticalStatsAllSources)
 
 	return r
 }

--- a/pkg/web/importstats.go
+++ b/pkg/web/importstats.go
@@ -69,6 +69,21 @@ func (c *Controller) importStatsFeed(ctx *gin.Context) {
 	c.importStatsFeedTmpl(ctx, selectImportStatsSQL)
 }
 
+func (c *Controller) critcalStatsSource(ctx *gin.Context) {
+	// TODO: Implement me!
+	ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Not Implemented, yet!"})
+}
+
+func (c *Controller) criticalStatsAllSources(ctx *gin.Context) {
+	// TODO: Implement me!
+	ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Not Implemented, yet!"})
+}
+
+func (c *Controller) critcalStatsFeed(ctx *gin.Context) {
+	// TODO: Implement me!
+	ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Not Implemented, yet!"})
+}
+
 func (c *Controller) importStatsSourceTmpl(ctx *gin.Context, sqlTmpl string) {
 	sourcesID, ok := parse(ctx, toInt64, ctx.Param("id"))
 	if !ok {

--- a/pkg/web/importstats.go
+++ b/pkg/web/importstats.go
@@ -43,48 +43,59 @@ const (
 		`%s ` + // placeholder for more filters.
 		`GROUP BY bucket ` +
 		`ORDER BY bucket`
+	selectCriticalSQL = `SELECT ` +
+		`date_bin($1, time, $2) AS bucket,` +
+		`critical,` +
+		`count(*) AS count ` +
+		`FROM downloads JOIN documents ON downloads.documents_id = documents.id ` +
+		`%s ` + // placeholder for deeper joins.
+		`WHERE time BETWEEN $2 AND $3 ` +
+		`%s ` + // placeholder for more filters.
+		`GROUP BY bucket, critical ` +
+		`ORDER BY bucket, critical`
 )
 
 func (c *Controller) cveStatsSource(ctx *gin.Context) {
-	c.importStatsSourceTmpl(ctx, selectCVEStatsSQL)
+	c.importStatsSourceTmpl(ctx, selectCVEStatsSQL, collectBuckets)
 }
 
 func (c *Controller) cveStatsFeed(ctx *gin.Context) {
-	c.importStatsFeedTmpl(ctx, selectCVEStatsSQL)
+	c.importStatsFeedTmpl(ctx, selectCVEStatsSQL, collectBuckets)
 }
 
 func (c *Controller) cveStatsAllSources(ctx *gin.Context) {
-	c.importStatsAllSourcesTmpl(ctx, selectCVEStatsSQL)
+	c.importStatsAllSourcesTmpl(ctx, selectCVEStatsSQL, collectBuckets)
 }
 
 func (c *Controller) importStatsSource(ctx *gin.Context) {
-	c.importStatsSourceTmpl(ctx, selectImportStatsSQL)
+	c.importStatsSourceTmpl(ctx, selectImportStatsSQL, collectBuckets)
 }
 
 func (c *Controller) importStatsAllSources(ctx *gin.Context) {
-	c.importStatsAllSourcesTmpl(ctx, selectImportStatsSQL)
+	c.importStatsAllSourcesTmpl(ctx, selectImportStatsSQL, collectBuckets)
 }
 
 func (c *Controller) importStatsFeed(ctx *gin.Context) {
-	c.importStatsFeedTmpl(ctx, selectImportStatsSQL)
+	c.importStatsFeedTmpl(ctx, selectImportStatsSQL, collectBuckets)
 }
 
-func (c *Controller) critcalStatsSource(ctx *gin.Context) {
-	// TODO: Implement me!
-	ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Not Implemented, yet!"})
+func (c *Controller) criticalStatsSource(ctx *gin.Context) {
+	c.importStatsSourceTmpl(ctx, selectCriticalSQL, collectCritcalBuckets)
 }
 
 func (c *Controller) criticalStatsAllSources(ctx *gin.Context) {
-	// TODO: Implement me!
-	ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Not Implemented, yet!"})
+	c.importStatsAllSourcesTmpl(ctx, selectCriticalSQL, collectCritcalBuckets)
 }
 
-func (c *Controller) critcalStatsFeed(ctx *gin.Context) {
-	// TODO: Implement me!
-	ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Not Implemented, yet!"})
+func (c *Controller) criticalStatsFeed(ctx *gin.Context) {
+	c.importStatsFeedTmpl(ctx, selectCriticalSQL, collectCritcalBuckets)
 }
 
-func (c *Controller) importStatsSourceTmpl(ctx *gin.Context, sqlTmpl string) {
+func (c *Controller) importStatsSourceTmpl(
+	ctx *gin.Context,
+	sqlTmpl string,
+	collectBuckets func(rows pgx.Rows) ([][]any, error),
+) {
 	sourcesID, ok := parse(ctx, toInt64, ctx.Param("id"))
 	if !ok {
 		return
@@ -103,10 +114,14 @@ func (c *Controller) importStatsSourceTmpl(ctx *gin.Context, sqlTmpl string) {
 			const joinFeeds = `JOIN feeds ON downloads.feeds_id = feeds.id`
 			sql := fmt.Sprintf(sqlTmpl, joinFeeds, cond.String())
 			return conn.Query(rctx, sql, step, from, to, sourcesID)
-		})
+		}, collectBuckets)
 }
 
-func (c *Controller) importStatsAllSourcesTmpl(ctx *gin.Context, sqlTmpl string) {
+func (c *Controller) importStatsAllSourcesTmpl(
+	ctx *gin.Context,
+	sqlTmpl string,
+	collectBuckets func(rows pgx.Rows) ([][]any, error),
+) {
 	from, to, step, ok := importStatsInterval(ctx)
 	if !ok {
 		return
@@ -119,10 +134,14 @@ func (c *Controller) importStatsAllSourcesTmpl(ctx *gin.Context, sqlTmpl string)
 		func(rctx context.Context, conn *pgxpool.Conn) (pgx.Rows, error) {
 			sql := fmt.Sprintf(sqlTmpl, "", cond.String())
 			return conn.Query(rctx, sql, step, from, to)
-		})
+		}, collectBuckets)
 }
 
-func (c *Controller) importStatsFeedTmpl(ctx *gin.Context, sqlTmpl string) {
+func (c *Controller) importStatsFeedTmpl(
+	ctx *gin.Context,
+	sqlTmpl string,
+	collectBuckets func(rows pgx.Rows) ([][]any, error),
+) {
 	feedID, ok := parse(ctx, toInt64, ctx.Param("id"))
 	if !ok {
 		return
@@ -140,12 +159,13 @@ func (c *Controller) importStatsFeedTmpl(ctx *gin.Context, sqlTmpl string) {
 		func(rctx context.Context, conn *pgxpool.Conn) (pgx.Rows, error) {
 			sql := fmt.Sprintf(sqlTmpl, "", cond.String())
 			return conn.Query(rctx, sql, step, from, to, feedID)
-		})
+		}, collectBuckets)
 }
 
 func (c *Controller) serveImportStats(
 	ctx *gin.Context,
 	query func(context.Context, *pgxpool.Conn) (pgx.Rows, error),
+	collectBuckets func(rows pgx.Rows) ([][]any, error),
 ) {
 	var list [][]any
 	if err := c.db.Run(
@@ -174,6 +194,39 @@ func collectBuckets(rows pgx.Rows) ([][]any, error) {
 			}
 			return []any{bucket.UTC(), count}, nil
 		})
+}
+
+func collectCritcalBuckets(rows pgx.Rows) ([][]any, error) {
+	defer rows.Close()
+	var (
+		list = [][]any{} // [[bucket, [[critical, count], ...]], ...]
+		bins [][]any
+		last time.Time
+	)
+	add := func(bucket time.Time, critical *float64, count int64) {
+		if len(bins) == 0 || bucket.Equal(last) {
+			bins = append(bins, []any{critical, count})
+		} else if len(bins) > 0 {
+			list = append(list, []any{last, bins})
+			bins = [][]any{{critical, count}}
+		}
+		last = bucket
+	}
+	for rows.Next() {
+		var (
+			bucket   time.Time
+			critical *float64
+			count    int64
+		)
+		if err := rows.Scan(&bucket, &critical, &count); err != nil {
+			return nil, fmt.Errorf("cannot scan criticals: %w", err)
+		}
+		add(bucket, critical, count)
+	}
+	if len(bins) > 0 {
+		list = append(list, []any{last, bins})
+	}
+	return list, nil
 }
 
 func importStatsInterval(ctx *gin.Context) (time.Time, time.Time, time.Duration, bool) {

--- a/pkg/web/importstats.go
+++ b/pkg/web/importstats.go
@@ -221,7 +221,7 @@ func collectCritcalBuckets(rows pgx.Rows) ([][]any, error) {
 		if err := rows.Scan(&bucket, &critical, &count); err != nil {
 			return nil, fmt.Errorf("cannot scan criticals: %w", err)
 		}
-		add(bucket, critical, count)
+		add(bucket.UTC(), critical, count)
 	}
 	if len(bins) > 0 {
 		list = append(list, []any{last, bins})


### PR DESCRIPTION
This is a sibling of PR #484 and PR #516 and offers the endpoints:

1. GET /stats/critical/source/:id
2. GET /stats/critical/feed/:id
3. GET /stats/critical

The arguments are all the same (see https://github.com/ISDuBA/ISDuBA/pull/484 for details).

The output is bit different. Example from my system:

```
 curl -s -D /dev/stderr --get \
-H "Authorization: Bearer $TOKEN" \
--data-urlencode 'from=2024-01-02' \
--data-urlencode 'to=2024-10-17' \
--data-urlencode 'step=24h' \
--data-urlencode 'download_failed=false' \
http://localhost:8081/api/stats/critical| jq .
```
results in (shortend):
```
[
  [
    "2024-10-11T00:00:00Z",
    [
      [ 0, 2 ],
      [ 1, 2 ],
      [ 1.2, 16 ],
      [ 1.4, 2 ],
      [ 1.5, 7 ],
      [ 1.7, 6 ],
      [ 1.8, 3 ],
      [ 1.9, 22 ],
      [ 2.1, 59 ],

      [ 9.1, 105 ],
      [ 9.3, 27 ],
      [ 9.4, 9 ],
      [ 9.6, 77 ],
      [ 9.8, 974 ],
      [ 9.9, 44 ],
      [ 10, 53 ],
      [ null, 8232 ]
    ]
  ],
  [
    "2024-10-14T00:00:00Z",
    [
      [ 4.4, 1 ],
      [ 5, 1 ],
      [ 6, 1 ],
      [ 7.5, 17 ],
      [ 8.8, 1 ],
      [ null, 53 ]
    ]
  ]
]
```

which is a list of lists with the inner lists having two elements.
The first element is the start time of the respective time interval.
The second argument is a list of two element lists.
These two element lists contains two values: The first is the critical value
and the second is the documents imported in this interval which
have this critical value.  `null`  as  a critical value are the documents which
don't have a critical value at all.