### PR TITLE
Stats: count documents and advisories

### DIFF
--- a/pkg/web/controller.go
+++ b/pkg/web/controller.go
@@ -178,6 +178,7 @@ func (c *Controller) Bind() http.Handler {
 	api.GET("/stats/cve/source/:id", authAll, c.cveStatsSource)
 	api.GET("/stats/cve/feed/:id", authAll, c.cveStatsFeed)
 	api.GET("/stats/cve", authAll, c.cveStatsAllSources)
+	api.GET("/stats/totals", authAll, c.statsTotal)
 
 	return r
 }

--- a/pkg/web/totalstats.go
+++ b/pkg/web/totalstats.go
@@ -10,12 +10,69 @@
 package web
 
 import (
+	"context"
+	"errors"
+	"log/slog"
 	"net/http"
+	"strconv"
+	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 func (c *Controller) statsTotal(ctx *gin.Context) {
-	// TODO: Implement me!
-	ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Not implemented, yet!"})
+	// Counting imports.
+	imports, ok := parse(ctx, strconv.ParseBool, ctx.DefaultQuery("imports", "false"))
+	if !ok {
+		return
+	}
+	var when time.Time
+	if t := ctx.Query("time"); t != "" {
+		var ok bool
+		if when, ok = parse(ctx, parseTime, t); !ok {
+			return
+		}
+	} else {
+		when = time.Now()
+	}
+	var (
+		documentsSQL, advisoriesSQL string
+		numDocuments, numAdvisories int64
+	)
+	if imports {
+		documentsSQL = `SELECT count(*) FROM documents ` +
+			`JOIN downloads ON documents.id = downloads.documents_id ` +
+			`WHERE time <= $1`
+		advisoriesSQL = `SELECT count(DISTINCT (publisher, tracking_id)) FROM documents ` +
+			`JOIN downloads ON documents.id = downloads.documents_id ` +
+			`WHERE time <= $1`
+	} else {
+		documentsSQL = `SELECT count(*) FROM documents ` +
+			`WHERE least(current_release_date, current_timestamp) <= $1`
+		advisoriesSQL = `SELECT count(DISTINCT (publisher, tracking_id)) FROM documents ` +
+			`WHERE least(current_release_date, current_timestamp) <= $1`
+	}
+	if err := c.db.Run(
+		ctx.Request.Context(),
+		func(rctx context.Context, conn *pgxpool.Conn) error {
+			tx, err := conn.BeginTx(rctx, pgx.TxOptions{AccessMode: pgx.ReadOnly})
+			if err != nil {
+				return err
+			}
+			defer tx.Rollback(rctx)
+			return errors.Join(
+				tx.QueryRow(rctx, documentsSQL, when).Scan(&numDocuments),
+				tx.QueryRow(rctx, advisoriesSQL, when).Scan(&numAdvisories))
+		}, 0,
+	); err != nil {
+		slog.Error("counting documents/advisories failed", "error", err)
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	ctx.JSON(http.StatusOK, gin.H{
+		"documents":  numDocuments,
+		"advisories": numAdvisories,
+	})
 }

--- a/pkg/web/totalstats.go
+++ b/pkg/web/totalstats.go
@@ -1,0 +1,21 @@
+// This file is Free Software under the Apache-2.0 License
+// without warranty, see README.md and LICENSES/Apache-2.0.txt for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: 2024 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+// Software-Engineering: 2024 Intevation GmbH <https://intevation.de>
+
+// Package web implements the endpoints of the web server.
+package web
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+func (c *Controller) statsTotal(ctx *gin.Context) {
+	// TODO: Implement me!
+	ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Not implemented, yet!"})
+}

--- a/pkg/web/totalstats.go
+++ b/pkg/web/totalstats.go
@@ -6,7 +6,6 @@
 // SPDX-FileCopyrightText: 2024 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
 // Software-Engineering: 2024 Intevation GmbH <https://intevation.de>
 
-// Package web implements the endpoints of the web server.
 package web
 
 import (


### PR DESCRIPTION
This PR adds an endpoint

- `GET` `/api/stats/totals`

to count documents and advisories.

with the optional query parameters `time` and `imports`. `time` defaults to now and may be
of format `time.RFC3339`, `time.DateTime` or `time.DateOnly`. `imports` defaults to false.

`time` determines the point in time when the counters should be probed.
`imports` determines if the documents should be counted by their import time stamps or
their current release dates. Documents with a current release date in the future are assumed to be imported by now.

Example usage from my system:

```
curl -s -D /dev/stderr --get \                                                             stats_total?
-H "Authorization: Bearer $TOKEN" \
--data-urlencode 'time=2024-10-18' \
--data-urlencode 'imports=false' \
http://localhost:8081/api/stats/totals | jq .
```

results in
```
{
  "advisories": 24286,
  "documents": 24570
}
```