### PR TITLE
Statistics: Probe imports in intervals

### DIFF
--- a/pkg/web/totalstats.go
+++ b/pkg/web/totalstats.go
@@ -90,7 +90,7 @@ func (c *Controller) statsTotal(ctx *gin.Context) {
 	if err := c.db.Run(
 		ctx.Request.Context(),
 		func(rctx context.Context, conn *pgxpool.Conn) error {
-			tx, err := conn.BeginTx(rctx, pgx.TxOptions{AccessMode: pgx.ReadOnly})
+			tx, err := conn.Begin(rctx)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
This PR modifies the endpoint

- `GET` `/api/stats/totals`

in a way to allow probing in intervals. They query parameter `time` is not supported any longer.
Instead the parameters `from`, `to` and `step` are introduced. `from` defaults to now.
if `to` is not given it is assumed to be the same value as `from`. If `step` is not given it will
be set to the length of the the interval from `from` to `to`.

Example from my system:
```
curl -s -D /dev/stderr --get \ 
-H "Authorization: Bearer $TOKEN" \
--data-urlencode 'from=2024-10-22' \
--data-urlencode 'to=2024-10-24' \
--data-urlencode 'step=24h' \     
--data-urlencode 'imports=false' \           
http://localhost:8081/api/stats/totals | jq .
```

results in
```
[
  [
    "2024-10-22T00:00:00Z",
    25525,
    25194
  ],
  [
    "2024-10-23T00:00:00Z",
    25570,
    25211
  ],
  [
    "2024-10-24T00:00:00Z",
    25588,
    25227
  ]
]
```

which is a list of 3-element lists. The first element in a 3-element list is the probe time, second and third are document ans advisory counts.

BTW: There is a limitation to the length of the list to ~32.000 entries. This due to SQL request strategy I have  chosen (batch queries). This could be done differently resulting in potential weaker performance.