### PR TITLE
Improve forwarder configuration and documentation

### DIFF
--- a/client/src/lib/Advisories/Advisory.svelte
+++ b/client/src/lib/Advisories/Advisory.svelte
@@ -307,7 +307,7 @@
     if (response.ok) {
       availableForwardSelection = [];
       for (let target of response.content) {
-        availableForwardSelection.push({ value: target.id, name: target.url });
+        availableForwardSelection.push({ value: target.id, name: target.name });
       }
     } else if (response.error) {
       loadForwardTargetsError = getErrorDetails(`Couldn't load forward targets.`, response);

--- a/docs/example_isdubad.toml
+++ b/docs/example_isdubad.toml
@@ -85,9 +85,15 @@
 # [forwarder]
 # update_interval = "5m"
 
-# This is a example target
-# [[forwarder.target]]
-# enabled = true
-# url = "http://example.com/api/v1/import"
-# header = [ "x-api-key:secret" ]
-# timeout = "5s"
+## These are example target
+## [[forwarder.target]]
+## automatic = true
+## name = "First example target"
+## url = "http://example.com/api/v1/import"
+## header = [ "x-api-key:secret" ]
+##
+## [[forwarder.target]]
+## enabled = false
+## name = "Second example target"
+## url = "http://example.org/api/v1/import"
+## header = [ "x-api-key:secret" ]

--- a/docs/example_isdubad.toml
+++ b/docs/example_isdubad.toml
@@ -85,7 +85,7 @@
 # [forwarder]
 # update_interval = "5m"
 
-## These are example target
+## These are example targets to show the forwarder target syntax.
 ## [[forwarder.target]]
 ## automatic = true
 ## name = "First example target"
@@ -93,7 +93,7 @@
 ## header = [ "x-api-key:secret" ]
 ##
 ## [[forwarder.target]]
-## enabled = false
+## automatic = false
 ## name = "Second example target"
-## url = "http://example.org/api/v1/import"
+## url = "https://example.org/api/v1/import"
 ## header = [ "x-api-key:secret" ]

--- a/docs/isdubad-config.md
+++ b/docs/isdubad-config.md
@@ -30,7 +30,6 @@ The configuration consists of the following sections:
 - [`[remote_validator]`](#section_remote_validator) Remote validator
 - [`[client]`](#section_client) Client configuration
 - [`[forwarder]`](#section_forwarder) Forwarder configuration
-- [`[[forwarder.target]]`](#section_forwarder_target) Forwarder target configuration
 
 ### <a name="section_general"></a> Section `[general]` General parameters
 
@@ -140,16 +139,19 @@ Valid values for `tlps` are the [Traffic Light Protocol](https://en.wikipedia.or
 
 - `update_interval`: Specifies how often the database is checked for new documents. Defaults to `"5m"`.
 
-### <a name="section_forwarder_target"></a> Section `[[forwarder.target]]` Forwarder target configuration
+#### Section `[[forwarder.target]]` Forwarder target configuration
 
 Only documents that are successfully imported into the database are forwarded.
 Documents that are discarded because of failed validation are not forwarded.
 
-- `enabled`: Specifies if the target automatically receives new documents. If disabled the target only receives documents on manual forwarding.
+- `automatic`: Specifies if the target automatically receives new documents. If disabled the target only receives documents on manual forwarding.
 - `url`: The URL of the forward target.
+- `name`: The name of target. This value will be displayed on manual forwarding the document.
 - `publisher`: Specifies the publisher of the documents that need to be forwarded.
 - `header`: List all headers that are sent to the target. The format is `key:value`.
-- `timeout`: Sets the http client timeout. It is recommended to set this value, to avoid problems on network errors.
+- `private_cert`: The location of the private client certificate.
+- `public_cert`: The location of the public client certificate.
+- `timeout`: Sets the http client timeout. Set this value if the network is unstable.
 
 ## <a name="env_vars"></a>Environment variables
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -203,11 +203,12 @@ type Sources struct {
 // ForwardTarget are the config options for the forward target.
 type ForwardTarget struct {
 	URL               string        `toml:"url"`
+	Name              string        `toml:"name"`
 	ClientPrivateCert string        `toml:"private_cert"`
 	ClientPublicCert  string        `toml:"public_cert"`
 	Publisher         *string       `toml:"publisher"`
 	Header            []string      `toml:"header"`
-	Enabled           bool          `toml:"enabled"`
+	Automatic         bool          `toml:"automatic"`
 	Timeout           time.Duration `toml:"timeout"`
 }
 


### PR DESCRIPTION
- Rename enabled to automatic
- Don't show automatic targets for manual forward
- Fix documentation style and wording
- Add an optional name parameter to the forward target