### PR TITLE
Remove logging of admin URL

### DIFF
--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -94,7 +94,6 @@ func doMigrations(
 	migs []migration,
 ) (bool, error) {
 	if err := func() error {
-		slog.InfoContext(ctx, "admin url", "url", cfg.AdminURL())
 		conn, err := pgx.Connect(ctx, cfg.AdminURL())
 		if err != nil {
 			return err


### PR DESCRIPTION
This information contains sensitive information, like the database credentials and should be avoided from being logged.

Closes #559