### PR TITLE
feat: Remove multiple tooltips that didn't add new information

### DIFF
--- a/client/src/lib/Advisories/CSAFWebview/Collapsible.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/Collapsible.svelte
@@ -10,6 +10,7 @@
 
 <script lang="ts">
   export let header: string;
+  export let title: string | undefined = undefined;
   export let open = false;
   export let level = 2;
   export let highlight = false;
@@ -71,7 +72,7 @@
 <div class:collapsible={true} class:highlight-section={highlight}>
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <!-- svelte-ignore a11y-no-static-element-interactions -->
-  <div title={header} id={header}>
+  <div {title} id={header}>
     <div class="inline-flex items-center" on:click={toggle}>
       <i class="bx {getClass(level)} {icon}" />
       <slot class={getClass(level)} name="header"

--- a/client/src/lib/Advisories/CSAFWebview/productvulnerabilities/ProductVulnerabilities.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/productvulnerabilities/ProductVulnerabilities.svelte
@@ -158,7 +158,6 @@
                   <TableBodyCell tdClass={tdClass + " sticky left-0 bg-inherit"}>
                     <div class="max-w-1/2 min-w-56 whitespace-normal text-wrap break-all">
                       <a
-                        title={$appStore.webview.doc?.productsByID[column.content]}
                         id={crypto.randomUUID()}
                         href={basePath + "product-" + encodeURIComponent(column.content)}
                         class={innerLinkStyle}

--- a/client/src/lib/Advisories/SSVC/SSVCCalculator.svelte
+++ b/client/src/lib/Advisories/SSVC/SSVCCalculator.svelte
@@ -379,17 +379,9 @@
       <div class="mt-4 flex flex-col">
         <div class="ml-auto flex flex-row gap-x-3">
           {#if currentStep > 0}
-            <Button color="light" size="xs" title="Step back" class="h-6 p-3" on:click={stepBack}
-              >Back</Button
-            >
+            <Button color="light" size="xs" class="h-6 p-3" on:click={stepBack}>Back</Button>
           {/if}
-          <Button
-            size="xs"
-            color="light"
-            title="Restart process"
-            class="h-6 text-nowrap p-3"
-            on:click={resetUserDecisions}
-          >
+          <Button size="xs" color="light" class="h-6 text-nowrap p-3" on:click={resetUserDecisions}>
             Restart
           </Button>
           {#if isComplex || result}

--- a/client/src/lib/Advisories/SSVC/SSVCCalculator.svelte
+++ b/client/src/lib/Advisories/SSVC/SSVCCalculator.svelte
@@ -282,7 +282,6 @@
           outline
           size="xs"
           class="h-8"
-          title="Cancel"
           on:click={() => {
             isEditing = false;
           }}
@@ -293,15 +292,12 @@
           outline
           size="xs"
           class="h-8"
-          title="Evaluate"
           {disabled}
           on:click={() => (startedCalculation = true)}
         >
           Evaluate
         </Button>
-        <Button size="xs" class="h-8" title="Save" on:click={() => saveSSVC(vectorInput)}>
-          Save
-        </Button>
+        <Button size="xs" class="h-8" on:click={() => saveSSVC(vectorInput)}>Save</Button>
       </div>
     </div>
   {:else}
@@ -358,7 +354,6 @@
                 <Button
                   class="h-6"
                   outline
-                  title="Custom"
                   size="xs"
                   on:click={() => {
                     isComplex = true;


### PR DESCRIPTION
Closes #340 

Places:
- Collapsible: Tooltips can now be set via the 'title' attribute, which is currently unused
- Overview doesn't show the product title tooltips any more
- SSVC Calculator had multiple buttons where the tooltip had the exact same content as the button, removed those tooltips