### PR TITLE
fix: return valid boundaries if slot value is out of range

### DIFF
--- a/pkg/sources/manager.go
+++ b/pkg/sources/manager.go
@@ -1154,9 +1154,10 @@ func (su *SourceUpdater) UpdateSlots(slots *int) error {
 	if slots != nil && su.updatable.slots != nil && *slots == *su.updatable.slots {
 		return nil
 	}
-	if slots != nil && (*slots < 1 ||
-		*slots > su.manager.cfg.Sources.MaxSlotsPerSource && su.manager.cfg.Sources.MaxSlotsPerSource != 0) {
-		return InvalidArgumentError("slot value ot ouf range")
+	if msps := su.manager.cfg.Sources.MaxSlotsPerSource; slots != nil &&
+		(*slots < 1 || *slots > msps && msps != 0) {
+		msg := fmt.Sprintf("slot value out of range: %d not in [1, %d]", *slots, msps)
+		return InvalidArgumentError(msg)
 	}
 	su.addChange(func(s *source) { s.slots = slots }, "slots", slots)
 	return nil


### PR DESCRIPTION
resolves #520

```
curl -s -D /dev/stderr -X PUT \                                   slot_range?
-H "Authorization: Bearer $TOKEN" \
--data 'slots=1000' \
http://localhost:8081/api/sources/3 | jq .
HTTP/1.1 400 Bad Request
Content-Type: application/json; charset=utf-8
X-Request-Id: 58b1ee4a-5fb4-4198-a754-2f01e0330840
Date: Wed, 06 Nov 2024 19:35:28 GMT
Content-Length: 77

{
  "error": "updates failed: slot value out of range range: 1000 not in [1, 2]"
}
```