### PR TITLE
feat: Improve feed log information access

### DIFF
--- a/client/src/lib/Sources/FeedLogViewer.svelte
+++ b/client/src/lib/Sources/FeedLogViewer.svelte
@@ -81,10 +81,7 @@
   };
 
   const loadLogs = async () => {
-    if (!feed) {
-      return;
-    }
-    if (!feed.id) {
+    if (!feed || !feed.id) {
       return;
     }
     loadingLogs = true;
@@ -98,10 +95,7 @@
   };
 
   const downloadFeedLogs = async () => {
-    if (!feed) {
-      return;
-    }
-    if (!feed.id) {
+    if (!feed || !feed.id) {
       return;
     }
     let result = await fetchAllFeedLogs(feed.id, false);

--- a/client/src/lib/Sources/FeedLogViewer.svelte
+++ b/client/src/lib/Sources/FeedLogViewer.svelte
@@ -119,7 +119,9 @@
         { name: "10", value: 10 },
         { name: "25", value: 25 },
         { name: "50", value: 50 },
-        { name: "100", value: 100 }
+        { name: "100", value: 100 },
+        { name: "1000", value: 1000 },
+        { name: "10000", value: 10000 }
       ]}
       bind:value={limit}
       on:change={async () => {

--- a/client/src/lib/Sources/source.ts
+++ b/client/src/lib/Sources/source.ts
@@ -591,6 +591,17 @@ const fetchFeedLogs = async (
   return { ok: false, error: getErrorDetails(`Could not load feed logs`, resp) };
 };
 
+const fetchAllFeedLogs = async (
+  id: number,
+  count: boolean = false
+): Promise<Result<[any[], number], ErrorDetails>> => {
+  const resp = await request(`/api/sources/feeds/${id}/log?count=${count}`, "GET");
+  if (resp.ok) {
+    return { ok: true, value: [resp.content.entries, resp.content.count ?? 0] };
+  }
+  return { ok: false, error: getErrorDetails(`Could not load feed logs`, resp) };
+};
+
 const isSameFeed = (a: Feed, b: Feed) => a.url === b.url && a.rolie === b.rolie;
 
 const calculateMissingFeeds = (pmdFeeds: Feed[], feeds: Feed[]): Feed[] => {
@@ -624,6 +635,7 @@ export {
   getSourceName,
   calculateMissingFeeds,
   fetchFeedLogs,
+  fetchAllFeedLogs,
   parseHeaders,
   parseFeeds,
   deleteFeed,


### PR DESCRIPTION
See #585 

Increase upper limit on page pagination to 10000
Downloadable log file per feed (json file with feed name title for now -> Is there any preferred format?)