### PR TITLE
Force aggregator schema validation

### DIFF
--- a/client/src/lib/Sources/source.ts
+++ b/client/src/lib/Sources/source.ts
@@ -442,13 +442,9 @@ const deleteAggregator = async (id: number): Promise<Result<null, ErrorDetails>>
 };
 
 const fetchAggregatorData = async (
-  url: string,
-  validate: boolean = false
+  url: string
 ): Promise<Result<AggregatorMetadata, ErrorDetails>> => {
-  const resp = await request(
-    `/api/aggregator?url=${encodeURIComponent(url)}&validate=${validate}`,
-    "GET"
-  );
+  const resp = await request(`/api/aggregator?url=${encodeURIComponent(url)}`, "GET");
   if (resp.ok) {
     return {
       ok: true,

--- a/pkg/aggregators/manager.go
+++ b/pkg/aggregators/manager.go
@@ -116,7 +116,7 @@ func (m *Manager) refresh(ctx context.Context) {
 	fetch := func() {
 		defer wg.Done()
 		for agg := range toFetch {
-			cagg, err := m.Cache.GetAggregator(agg.url, false)
+			cagg, err := m.Cache.GetAggregator(agg.url)
 			if err != nil {
 				slog.Warn("fetching aggregator failed", "url", agg.url, "err", err)
 				continue

--- a/pkg/web/aggregators.go
+++ b/pkg/web/aggregators.go
@@ -38,7 +38,7 @@ type argumentedAggregator struct {
 
 func (c *Controller) aggregatorProxy(ctx *gin.Context) {
 	url := ctx.Query("url")
-	ca, err := c.am.Cache.GetAggregator(url, true)
+	ca, err := c.am.Cache.GetAggregator(url)
 	if err != nil {
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
@@ -113,10 +113,6 @@ func (c *Controller) viewAggregator(ctx *gin.Context) {
 	if !ok {
 		return
 	}
-	validate, ok := parse(ctx, strconv.ParseBool, ctx.DefaultQuery("validate", "false"))
-	if !ok {
-		return
-	}
 	var (
 		name      string
 		url       string
@@ -139,7 +135,7 @@ func (c *Controller) viewAggregator(ctx *gin.Context) {
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	ca, err := c.am.Cache.GetAggregator(url, validate)
+	ca, err := c.am.Cache.GetAggregator(url)
 	if err != nil {
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return

--- a/pkg/web/aggregators.go
+++ b/pkg/web/aggregators.go
@@ -37,12 +37,8 @@ type argumentedAggregator struct {
 }
 
 func (c *Controller) aggregatorProxy(ctx *gin.Context) {
-	validate, ok := parse(ctx, strconv.ParseBool, ctx.DefaultQuery("validate", "false"))
-	if !ok {
-		return
-	}
 	url := ctx.Query("url")
-	ca, err := c.am.Cache.GetAggregator(url, validate)
+	ca, err := c.am.Cache.GetAggregator(url, true)
 	if err != nil {
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return


### PR DESCRIPTION
After upgrading the gocsaf/csaf dependency, it is possible to validate the aggregator schema correctly. This pull request removes the `validate` parameter from the aggregator proxy endpoint.