### PR TITLE
Ignore empty patterns in regexes in download filtering

### DIFF
--- a/pkg/sources/util.go
+++ b/pkg/sources/util.go
@@ -30,14 +30,18 @@ func AsRegexps(s []string) ([]*regexp.Regexp, error) {
 	if s == nil {
 		return nil, nil
 	}
-	slice := make([]*regexp.Regexp, len(s))
-	for i, x := range s {
+	slice := make([]*regexp.Regexp, 0, len(s))
+	for _, x := range s {
+		// Ignore empty strings.
+		if x == "" {
+			continue
+		}
 		re, err := regexp.Compile(x)
 		if err != nil {
 			return nil, InvalidArgumentError(
 				fmt.Sprintf("ignore pattern %q is not a valid regexp: %v", x, err))
 		}
-		slice[i] = re
+		slice = append(slice, re)
 	}
 	return slice, nil
 }


### PR DESCRIPTION
Do not try to use empty strings for filtering.