### PR TITLE
More dark mode refinements

### DIFF
--- a/client/src/lib/Queries/QueryDesigner.svelte
+++ b/client/src/lib/Queries/QueryDesigner.svelte
@@ -51,7 +51,7 @@
 
   const basicButtonClass = "h-8";
   const buttonClass = `${basicButtonClass} bg-white hover:bg-gray-100`;
-  const pressedButtonClass = `${basicButtonClass} bg-gray-200 text-black hover:!bg-gray-100`;
+  const pressedButtonClass = `${basicButtonClass} bg-gray-200 text-black hover:!bg-gray-100 dark:bg-gray-600 dark:hover:!bg-gray-700`;
 
   // Prop items of (Multi-)Select doesn't accept simple strings
   const roles = [{ name: "<no role>", value: "" }].concat(

--- a/client/src/lib/Search/Overview.svelte
+++ b/client/src/lib/Search/Overview.svelte
@@ -166,7 +166,7 @@
       <Button
         size="xs"
         color="light"
-        class={`h-7 py-1 text-xs ${query.queryType === SEARCHTYPES.ADVISORY ? "bg-gray-200 hover:bg-gray-100" : ""}`}
+        class={`h-7 py-1 text-xs ${query.queryType === SEARCHTYPES.ADVISORY ? "bg-gray-200 hover:bg-gray-100 dark:bg-gray-600 dark:hover:bg-gray-700" : ""}`}
         on:click={() => {
           query.queryType = SEARCHTYPES.ADVISORY;
           query.columns = SEARCHPAGECOLUMNS.ADVISORY;
@@ -185,7 +185,7 @@
       <Button
         size="xs"
         color="light"
-        class={`h-7 py-1 text-xs ${query.queryType === SEARCHTYPES.DOCUMENT ? "bg-gray-200 hover:bg-gray-100" : ""}`}
+        class={`h-7 py-1 text-xs ${query.queryType === SEARCHTYPES.DOCUMENT ? "bg-gray-200 hover:bg-gray-100 dark:bg-gray-600 dark:hover:bg-gray-700" : ""}`}
         on:click={() => {
           query.queryType = SEARCHTYPES.DOCUMENT;
           query.columns = SEARCHPAGECOLUMNS.DOCUMENT;
@@ -204,7 +204,7 @@
       <Button
         size="xs"
         color="light"
-        class={`h-7 py-1 text-xs ${query.queryType === SEARCHTYPES.EVENT ? "bg-gray-200 hover:bg-gray-100" : ""}`}
+        class={`h-7 py-1 text-xs ${query.queryType === SEARCHTYPES.EVENT ? "bg-gray-200 hover:bg-gray-100 dark:bg-gray-600 dark:hover:bg-gray-700" : ""}`}
         on:click={() => {
           query.queryType = SEARCHTYPES.EVENT;
           query.columns = SEARCHPAGECOLUMNS.EVENT;

--- a/client/src/lib/Search/Queries.svelte
+++ b/client/src/lib/Search/Queries.svelte
@@ -35,12 +35,13 @@
   let ignoredQueries: Query[] = [];
   let errorMessage: ErrorDetails | null;
   let advancedQueryErrorMessage: ErrorDetails | null;
-  let globalQueryButtonColor = "primary";
-  let defaultQueryButtonClass = "flex flex-col p-0 focus:text-black hover:text-black";
-  let queryButtonClass = "bg-white hover:bg-gray-100";
-  let pressedQueryButtonClass = "bg-gray-200 text-black hover:!bg-gray-100";
-  let globalQueryButtonClass = `border-${globalQueryButtonColor}-500 hover:!text-black`;
-  let pressedGlobalQueryButtonClass = `border-${globalQueryButtonColor}-500 bg-${globalQueryButtonColor}-600 focus:text-white text-white hover:text-black`;
+  const globalQueryButtonColor = "primary";
+  const defaultQueryButtonClass = "flex flex-col p-0";
+  const queryButtonClass = "bg-white hover:bg-gray-100";
+  const pressedQueryButtonClass =
+    "bg-gray-200 text-black hover:text-black hover:!bg-gray-100 dark:bg-gray-600 dark:hover:!bg-gray-700";
+  const globalQueryButtonClass = `border-${globalQueryButtonColor}-500 dark:border-${globalQueryButtonColor}-500 dark:hover:border-${globalQueryButtonColor}-500 hover:!text-black dark:hover:!text-white`;
+  const pressedGlobalQueryButtonClass = `border-${globalQueryButtonColor}-500 bg-${globalQueryButtonColor}-600 dark:bg-${globalQueryButtonColor}-600 dark:border-${globalQueryButtonColor}-500 dark:hover:border-${globalQueryButtonColor}-500 focus:text-white hover:focus:text-black text-white hover:text-black dark:hover:text-white dark:hover:focus:text-white dark:focus:text-white`;
 
   const getClass = (isGlobal: boolean, isPressed: boolean) => {
     const addition = isGlobal

--- a/client/src/lib/Sources/FeedLogViewer.svelte
+++ b/client/src/lib/Sources/FeedLogViewer.svelte
@@ -169,7 +169,7 @@
 
       <div class="flex flex-row flex-wrap items-center">
         <input
-          class={`${numberOfPages < 10000 ? "w-16" : "w-20"} cursor-pointer border pr-1 text-right dark:text-black`}
+          class={`${numberOfPages < 10000 ? "w-16" : "w-20"} cursor-pointer border pr-1 text-right dark:bg-gray-800 dark:text-white`}
           on:change={() => {
             if (!parseInt("" + currentPage)) currentPage = 1;
             currentPage = Math.floor(currentPage);


### PR DESCRIPTION
Before, if you selected a button for the query type in `Search` the button wasn't highlighted. This is fixed by this PR.
![type_switch](https://github.com/user-attachments/assets/03d21b81-121a-49b6-8076-b09953cea3c2)

The background of the input field for the current page in the `FeedLogViewer` was white before. This PR changes the background to dark gray so it is consistent to the input field in `Search`.
![input](https://github.com/user-attachments/assets/846cb297-c389-403b-a82a-e33997b78691)