### PR TITLE
More query parameters to filter feed logs.

### DIFF
--- a/pkg/database/query/sqlbuilder.go
+++ b/pkg/database/query/sqlbuilder.go
@@ -40,7 +40,9 @@ var (
 	whiteSpaces = regexp.MustCompile(`\s+`)
 )
 
-func likeQuery(query string) string {
+// LikeEscape quotes a query string to be more convenient
+// to use with LIKE filters.
+func LikeEscape(query string) string {
 	query = strings.TrimSpace(query)
 	query = escapeLike(query)
 	query = whiteSpaces.ReplaceAllString(query, `%`)
@@ -49,7 +51,7 @@ func likeQuery(query string) string {
 
 func (sb *SQLBuilder) searchWhere(e *Expr, b *strings.Builder) {
 	fmt.Fprintf(b, "txt ILIKE $%d",
-		sb.replacementIndex(likeQuery(e.stringValue))+1)
+		sb.replacementIndex(LikeEscape(e.stringValue))+1)
 
 	// We need the text tables to be joined.
 	sb.TextTables = true
@@ -71,15 +73,15 @@ func (sb *SQLBuilder) mentionedWhere(e *Expr, b *strings.Builder) {
 			"ON comments.documents_id = docs.id "+
 			"WHERE message ILIKE $%d "+
 			"AND docs.publisher = documents.publisher AND docs.tracking_id = documents.tracking_id)",
-			sb.replacementIndex(likeQuery(e.stringValue))+1)
+			sb.replacementIndex(LikeEscape(e.stringValue))+1)
 	case DocumentMode:
 		fmt.Fprintf(b, "EXISTS(SELECT 1 FROM comments WHERE message ILIKE $%d "+
 			"AND comments.documents_id = documents.id)",
-			sb.replacementIndex(likeQuery(e.stringValue))+1)
+			sb.replacementIndex(LikeEscape(e.stringValue))+1)
 	case EventMode:
 		fmt.Fprintf(b, "EXISTS(SELECT 1 FROM comments WHERE message ILIKE $%d "+
 			"AND comments.id = events_log.comments_id)",
-			sb.replacementIndex(likeQuery(e.stringValue))+1)
+			sb.replacementIndex(LikeEscape(e.stringValue))+1)
 	}
 }
 

--- a/pkg/sources/manager.go
+++ b/pkg/sources/manager.go
@@ -696,8 +696,9 @@ func (m *Manager) Feed(feedID int64, stats bool) *FeedInfo {
 
 // FeedLog sends the log of the feed with the given id to the given function.
 func (m *Manager) FeedLog(
-	feedID int64,
+	feedID *int64,
 	fn func(
+		id int64,
 		t time.Time,
 		lvl config.FeedLogLevel,
 		msg string),
@@ -707,13 +708,19 @@ func (m *Manager) FeedLog(
 ) (int64, error) {
 	const (
 		countSQL  = `SELECT count(*) FROM feed_logs WHERE `
-		selectSQL = `SELECT time, lvl::text, msg FROM feed_logs WHERE `
+		selectSQL = `SELECT feeds_id, time, lvl::text, msg FROM feed_logs WHERE `
 	)
 
 	var cond strings.Builder
-	cond.WriteString(`feeds_id = $1`)
+	var args []any
 
-	args := []any{feedID}
+	if feedID != nil {
+		cond.WriteString(`feeds_id = $1`)
+		args = append(args, *feedID)
+	} else {
+		cond.WriteString(`TRUE`)
+	}
+
 	if len(logLevels) > 0 {
 		cond.WriteString(` AND (`)
 		for i, lvl := range logLevels {
@@ -769,15 +776,16 @@ func (m *Manager) FeedLog(
 			}
 			defer rows.Close()
 			var (
+				id  int64
 				t   time.Time
 				lvl config.FeedLogLevel
 				msg string
 			)
 			for rows.Next() {
-				if err := rows.Scan(&t, &lvl, &msg); err != nil {
+				if err := rows.Scan(&id, &t, &lvl, &msg); err != nil {
 					return fmt.Errorf("scanning log failed: %w", err)
 				}
-				fn(t, lvl, msg)
+				fn(id, t, lvl, msg)
 			}
 			return rows.Err()
 		}, 0,

--- a/pkg/web/controller.go
+++ b/pkg/web/controller.go
@@ -180,6 +180,7 @@ func (c *Controller) Bind() http.Handler {
 	api.GET("/sources/feeds/:id", authEdSM, c.viewFeed)
 	api.PUT("/sources/feeds/:id", authSM, c.updateFeed)
 	api.DELETE("/sources/feeds/:id", authSM, c.deleteFeed)
+	api.GET("/sources/feeds/log", authSM, c.allFeedsLog)
 	api.GET("/sources/feeds/:id/log", authSM, c.feedLog)
 
 	// Import stats

--- a/pkg/web/sources.go
+++ b/pkg/web/sources.go
@@ -634,6 +634,7 @@ func (c *Controller) feedLogs(ctx *gin.Context, feedID *int64) {
 	}
 	var (
 		from, to      *time.Time
+		search              = ctx.Query("search")
 		limit, offset int64 = -1, -1
 		logLevels     []config.FeedLogLevel
 		count, ok     bool
@@ -687,6 +688,7 @@ func (c *Controller) feedLogs(ctx *gin.Context, feedID *int64) {
 	counter, err := c.sm.FeedLog(
 		feedID,
 		from, to,
+		search,
 		limit, offset, logLevels, count,
 		func(
 			id int64,


### PR DESCRIPTION
resolves #621 

This PR adds a new endpoint to access the logs to all feeds:

* GET `/api/sources/feeds/log`

This endpoint and the already existing

* GET `/api/sources/feeds/:id/log`

now have three more query parameters besides the already existing filtering by log levels:

* `from` start timestamp from which the log will be exported.
* `to` timestamp to which the log will be exported.
* `search` a search string looked up in the message of the logs.

This PR also adds a field `feed_id` to the output log entries.
