### PR TITLE
Avoid ad block preventing the download of logs

### DIFF
--- a/client/src/lib/Sources/source.ts
+++ b/client/src/lib/Sources/source.ts
@@ -595,7 +595,7 @@ const fetchAllFeedLogs = async (
   id: number,
   count: boolean = false
 ): Promise<Result<[any[], number], ErrorDetails>> => {
-  const resp = await request(`/api/sources/feeds/${id}/log?count=${count}`, "GET");
+  const resp = await request(`/api/sources/feeds/${id}/log?offset=0&count=${count}`, "GET");
   if (resp.ok) {
     return { ok: true, value: [resp.content.entries, resp.content.count ?? 0] };
   }


### PR DESCRIPTION
The popular EasyPrivacy list blocks all requests that start with `/log?count=`. Adding a null op parameter to the request avoids this issue.