### PR TITLE
feat: Move aggregator add form to modal

### DIFF
--- a/client/src/lib/Advisories/Advisory.svelte
+++ b/client/src/lib/Advisories/Advisory.svelte
@@ -49,6 +49,7 @@
   let position = "";
   let processRunning = false;
   let lastSuccessfulForwardTarget: number | undefined;
+  let openForwardModal = false;
 
   $: if ([NEW, READ, ASSESSING, REVIEW, ARCHIVED].includes(advisoryState)) {
     if (appStore.isReviewer() && [REVIEW].includes(advisoryState)) {
@@ -352,7 +353,6 @@
       appStore.setSelectedCVE("");
     }
   }
-  let openForwardModal = false;
 </script>
 
 <svelte:head>

--- a/client/src/lib/Sources/AggregatorViewer.svelte
+++ b/client/src/lib/Sources/AggregatorViewer.svelte
@@ -18,7 +18,7 @@
     resetAggregatorAttention
   } from "$lib/Sources/source";
   import SectionHeader from "$lib/SectionHeader.svelte";
-  import { Badge, Input, Spinner, Label, Button, TableBodyCell } from "flowbite-svelte";
+  import { Badge, Input, Spinner, Label, Button, TableBodyCell, Modal } from "flowbite-svelte";
   import CustomTable from "$lib/Table/CustomTable.svelte";
   import { tdClass } from "$lib/Table/defaults";
   import ErrorMessage from "$lib/Errors/ErrorMessage.svelte";
@@ -93,6 +93,8 @@
     name: "",
     url: ""
   };
+
+  let openAddModal = false;
 
   let formClass = "max-w-[800pt]";
   const smallColumnClass = "w-10 max-w-10 min-w-10";
@@ -261,6 +263,7 @@
       aggregator.url = "";
       await getAggregators();
     }
+    openAddModal = false;
   };
 
   const saveAggregatorExpand = () => {
@@ -290,8 +293,42 @@
   <title>Sources - Aggregator</title>
 </svelte:head>
 
+<Modal size="sm" bind:open={openAddModal}>
+  <form on:submit={submitAggregator} class={formClass}>
+    <div class="mx-auto flex flex-col gap-2">
+      <Label class="text-lg">Add aggregator</Label>
+      <div>
+        <Label>Name</Label>
+        <Input bind:value={aggregator.name} on:input={checkName} color={nameColor}></Input>
+      </div>
+      <div>
+        <Label>URL</Label>
+        <Input bind:value={aggregator.url} on:input={checkUrl} color={urlColor}></Input>
+      </div>
+      <Button
+        type="submit"
+        class="mt-2 w-fit"
+        color="light"
+        disabled={validUrl === false ||
+          validName === false ||
+          aggregator.name === "" ||
+          aggregator.url === ""}
+      >
+        <i class="bx bx-check me-2"></i>
+        <span>Save aggregator</span>
+      </Button>
+    </div>
+  </form>
+</Modal>
+
 <div>
-  <SectionHeader title="Aggregator"></SectionHeader>
+  <SectionHeader title="Aggregator">
+    {#if appStore.isSourceManager()}
+      <Button on:click={() => (openAddModal = true)} class="ml-3 !p-2" color="light">
+        <i class="bx bx-plus"></i>
+      </Button>
+    {/if}
+  </SectionHeader>
   <CustomTable
     headers={[
       {
@@ -469,32 +506,6 @@
       <ErrorMessage error={aggregatorError}></ErrorMessage>
     </div>
   </CustomTable>
-  {#if appStore.isSourceManager()}
-    <form on:submit={submitAggregator} class={formClass}>
-      <div class="flex w-96 flex-col gap-2">
-        <div>
-          <Label>Name</Label>
-          <Input bind:value={aggregator.name} on:input={checkName} color={nameColor}></Input>
-        </div>
-        <div>
-          <Label>URL</Label>
-          <Input bind:value={aggregator.url} on:input={checkUrl} color={urlColor}></Input>
-        </div>
-        <Button
-          type="submit"
-          class="mt-2 w-fit"
-          color="light"
-          disabled={validUrl === false ||
-            validName === false ||
-            aggregator.name === "" ||
-            aggregator.url === ""}
-        >
-          <i class="bx bx-check me-2"></i>
-          <span>Save aggregator</span>
-        </Button>
-      </div>
-    </form>
-  {/if}
   <ErrorMessage error={aggregatorSaveError}></ErrorMessage>
 
   <br />

--- a/client/src/lib/Sources/AggregatorViewer.svelte
+++ b/client/src/lib/Sources/AggregatorViewer.svelte
@@ -340,11 +340,13 @@
     } else {
       aggregator.name = "";
       aggregator.url = "";
+      sessionStorage.setItem(
+        "openAggregator",
+        JSON.stringify([...aggregatorData.keys(), result.value])
+      );
       await getAggregators();
-      const agg = aggregators.find((a) => a.id === result.value);
-      if (agg) {
-        await toggleAggregatorView(agg);
-      }
+      await restoreAggregatorExpand();
+      await new Promise((res) => setTimeout(res, 500));
       document.getElementById(`aggregator-${result.value}`)?.scrollIntoView({ behavior: "smooth" });
       blinkId = result.value;
       await new Promise((res) => setTimeout(res, 5000));


### PR DESCRIPTION
Old location below the list made it look like an afterthought and didn't quite fit in visually.
It also made the purpose of the aggregator viewer confusing, as it held both the function of a general overview and a create view at once.

With the modal the 'add' functionality is now separated from the overview.
The button is also placed in a prominent place right beside the view-title,
ensuring that no scrolling and searching is needed to find it, no matter how long the list is.