### PR TITLE
feat: Give advisory version buttons dynamic width

### DIFF
--- a/client/src/lib/Advisories/Version.svelte
+++ b/client/src/lib/Advisories/Version.svelte
@@ -24,7 +24,7 @@
   let firstDocumentIndex: number | undefined;
   let secondDocumentIndex: number | undefined;
   let nextColor = "red";
-  const diffButtonBaseClass = "!p-2 h-8 w-8 mb-2";
+  const diffButtonBaseClass = "!p-2 h-8 min-w-8 mb-2";
   const versionButtonClass = "dark:text-white text-black hover:text-black border border-solid";
   const redButtonClass = `${versionButtonClass} bg-red-100 group-hover:bg-red-300 border-red-700 dark:bg-red-700 dark:group-hover:bg-red-500 dark:border-red-100`;
   const greenButtonClass = `${versionButtonClass} bg-green-100 group-hover:bg-green-300 border-green-700 dark:bg-green-700 dark:group-hover:bg-green-500 dark:border-green-100`;


### PR DESCRIPTION
Turned former fixed width into min width to ensure the button gets wider on longer version numbers

This ensures that long version numbers don't flow out of the button like in this example:
![Screenshot_20241114_160354](https://github.com/user-attachments/assets/b3d38eba-16a4-4c3c-9aad-4bbdf9392286)
