### PR TITLE
fix: build-in version for release tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,13 +13,13 @@ all: build_isdubad build_importer build_client test
 # See comment here (2024-04-05)
 # https://github.com/gocsaf/csaf/blob/d909e9de151d5845fe0c0d5b9db2152f9db25e90/Makefile#L40-L49
 
-GITDESC := $(shell git describe --tags --always)
-GITDESCPATCH := $(shell echo '$(GITDESC)' | sed -E 's/v?[0-9]+\.[0-9]+\.([0-9]+)[-+]?.*/\1/')
+GITDESC := $(shell git describe --tags --always | sed -E 's/^v//')
+GITDESCPATCH := $(shell echo '$(GITDESC)' | sed -E 's/[0-9]+\.[0-9]+\.([0-9]+)[-+]?.*/\1/')
 SEMVERPATCH := $(shell echo $$(( $(GITDESCPATCH) + 1 )))
 # Hint: The regexp in the next line only matches if there is a hyphen (`-`)
 #       followed by a number, by which we assume that git describe
 #       has added a string after the tag
-SEMVER := $(shell echo '$(GITDESC)' | sed -E 's/v?([0-9]+\.[0-9]+\.)([0-9]+)(-[1-9].*)/\1$(SEMVERPATCH)\3/' )
+SEMVER := $(shell echo '$(GITDESC)' | sed -E 's/([0-9]+\.[0-9]+\.)([0-9]+)(-[1-9].*)/\1$(SEMVERPATCH)\3/' )
 testsemver:
 	@echo from \'$(GITDESC)\' transformed to \'$(SEMVER)\'
 


### PR DESCRIPTION
 * Change Makefile to remove the leading `v` from the git tag in the case of release tags. Previously this was only done for pre-release git tags.

resolve #651 