### PR TITLE
Save filename on import

### DIFF
--- a/cmd/bulkimport/main.go
+++ b/cmd/bulkimport/main.go
@@ -83,9 +83,27 @@ func processFile(
 			_, err := tx.Exec(ctx, insertSQL, docID)
 			return err
 		}
+		// Store filename
+		storeFilename := func(ctx context.Context, tx pgx.Tx, docID int64, duplicate bool) error {
+			if duplicate {
+				return nil
+			}
+			const insertSQL = `UPDATE documents ` +
+				`SET filename = $1 ` +
+				`WHERE id = $2`
+			_, err := tx.Exec(ctx, insertSQL, filepath.Base(path), docID)
+			return err
+		}
+		storeMetadata := func(ctx context.Context, tx pgx.Tx, docID int64, duplicate bool) error {
+			if err := storeStats(ctx, tx, docID, duplicate); err != nil {
+				return err
+			}
+			return storeFilename(ctx, tx, docID, duplicate)
+		}
+
 		var id int64
 		if err = db.Run(ctx, func(ctx context.Context, conn *pgxpool.Conn) error {
-			id, err = models.ImportDocument(ctx, conn, r, actor, nil, storeStats, dry)
+			id, err = models.ImportDocument(ctx, conn, r, actor, nil, storeMetadata, dry)
 			return err
 		}, 0); err != nil {
 			if errors.Is(err, models.ErrAlreadyInDatabase) {

--- a/pkg/web/documents.go
+++ b/pkg/web/documents.go
@@ -166,13 +166,29 @@ func (c *Controller) importDocument(ctx *gin.Context) {
 		_, err := tx.Exec(ctx, insertSQL, docID)
 		return err
 	}
-
+	// Store filename
+	storeFilename := func(ctx context.Context, tx pgx.Tx, docID int64, duplicate bool) error {
+		if duplicate {
+			return nil
+		}
+		const insertSQL = `UPDATE documents ` +
+			`SET filename = $1 ` +
+			`WHERE id = $2`
+		_, err := tx.Exec(ctx, insertSQL, file.Filename, docID)
+		return err
+	}
+	storeMetadata := func(ctx context.Context, tx pgx.Tx, docID int64, duplicate bool) error {
+		if err := storeStats(ctx, tx, docID, duplicate); err != nil {
+			return err
+		}
+		return storeFilename(ctx, tx, docID, duplicate)
+	}
 	var id int64
 	switch err := c.db.Run(
 		ctx.Request.Context(),
 		func(rctx context.Context, conn *pgxpool.Conn) error {
 			id, err = models.ImportDocumentData(
-				rctx, conn, document, buf.Bytes(), actor, c.tlps(ctx), storeStats, false)
+				rctx, conn, document, buf.Bytes(), actor, c.tlps(ctx), storeMetadata, false)
 			return err
 		}, 0,
 	); {


### PR DESCRIPTION
The filename was only saved if the source manager downloaded it. Now the bulk importer and the import API also save the filename.

Closes #668