### PR TITLE
fix: Show stats of manual imports in source overview

### DIFF
--- a/client/src/lib/Sources/Overview.svelte
+++ b/client/src/lib/Sources/Overview.svelte
@@ -132,9 +132,13 @@
             <TableBodyCell {tdClass}
               >{source.stats?.downloading}/{source.stats?.waiting}</TableBodyCell
             >
+          {:else}
+            <TableBodyCell></TableBodyCell>
+            <TableBodyCell></TableBodyCell>
+            <TableBodyCell></TableBodyCell>
           {/if}
           <TableBodyCell>
-            {#if source.id}
+            {#if source.id !== undefined}
               {@const yesterday = Date.now() - DAY_MS}
               <SourceBasicStats sourceID={source.id}></SourceBasicStats>
               (<SourceBasicStats from={new Date(yesterday)} sourceID={source.id}


### PR DESCRIPTION
IIRC we had them already but probably they were removed by accident when domain etc. from the fake source were removed.

![import_stats](https://github.com/user-attachments/assets/55074d78-59a4-4799-bfd6-38f3bf314e6c)
