### PR TITLE
Use the correct name of the standard

### DIFF
--- a/client/src/lib/Sources/SourceForm.svelte
+++ b/client/src/lib/Sources/SourceForm.svelte
@@ -324,7 +324,7 @@
           >Check TLS certificates</CCheckbox
         >
         <CCheckbox on:change={inputChange} bind:checked={source.signature_check}
-          >Check document PGP signature</CCheckbox
+          >Check document OpenPGP signature</CCheckbox
         >
       </div>
 


### PR DESCRIPTION
OpenPGP is the name of the standard while PGP is the name of an encryption program.