### PR TITLE
Improvement of stats

### DIFF
--- a/client/src/lib/Statistics/ImportStats.svelte
+++ b/client/src/lib/Statistics/ImportStats.svelte
@@ -596,14 +596,14 @@
           >
         </ButtonGroup>
       {/if}
+      {#if isLoading}
+        <div class:invisible={!isLoading} class={isLoading ? "loadingFadeIn" : ""}>
+          Loading ...
+          <Spinner color="gray" size="4"></Spinner>
+        </div>
+      {/if}
     </div>
     <ErrorMessage {error}></ErrorMessage>
-    {#if isLoading}
-      <div class:invisible={!isLoading} class={isLoading ? "loadingFadeIn" : ""}>
-        Loading ...
-        <Spinner color="gray" size="4"></Spinner>
-      </div>
-    {/if}
     <div hidden={mode === "table"} class="border px-2">
       <div style:height>
         <canvas bind:this={chartComponentRef}></canvas>

--- a/client/src/lib/Statistics/statistics.ts
+++ b/client/src/lib/Statistics/statistics.ts
@@ -87,7 +87,7 @@ const getLabelForKey = (key: string): string => {
   let label = key;
   if (key === "cve") label = "CVEs of documents";
   if (key === "imports") label = "Imports";
-  if (key === "importFailuresCombined") label = "Imports errors";
+  if (key === "importFailuresCombined") label = "Import errors";
   if (key === "signatureFailed") label = "Failed signature checks";
   if (key === "checksumFailed") label = "Failed checksum checks";
   if (key === "filenameFailed") label = "Failed filename checks";


### PR DESCRIPTION
Show loading indicator next to header -> prevent jumping when selecting date range
![stats_loading](https://github.com/user-attachments/assets/2a5bb65d-6223-4f9e-b261-8328f0bd09ab)

Also improve wording of a label used in a legend (see 0dc309d36d0b4d27c91836afd2a28bc07f9ed86d).