### PR TITLE
Restrict HTTP dialing to remote hosts

### DIFF
--- a/cmd/isdubad/main.go
+++ b/cmd/isdubad/main.go
@@ -61,7 +61,7 @@ func run(cfg *config.Config) error {
 	forwardManager := forwarder.NewForwardManager(&cfg.Forwarder, db)
 	go forwardManager.Run(ctx)
 
-	agg := aggregators.NewManager(&cfg.Aggregators, db)
+	agg := aggregators.NewManager(cfg, db)
 	go agg.Run(ctx)
 
 	// Is the remote validator configured?

--- a/docs/example_isdubad.toml
+++ b/docs/example_isdubad.toml
@@ -9,6 +9,18 @@
 # [general]
 # advisory_upload_limit = "512K"
 # anonymous_event_logging = false
+# allowed_ports = [80, 443]
+# block_loopback = true
+# blocked_ranges = [
+#      "127.0.0.0/8",    # IPv4 loopback
+#      "10.0.0.0/8",     # RFC1918
+#      "172.16.0.0/12",  # RFC1918
+#      "192.168.0.0/16", # RFC1918
+#      "169.254.0.0/16", # RFC3927 link-local
+#      "::1/128",        # IPv6 loopback
+#      "fe80::/10",      # IPv6 link-local
+#      "fc00::/7"        # IPv6 unique local addr
+# ]
 
 # [log]
 # file = "isduba.log"

--- a/docs/example_isdubad.toml
+++ b/docs/example_isdubad.toml
@@ -21,6 +21,7 @@
 #      "fe80::/10",      # IPv6 link-local
 #      "fc00::/7"        # IPv6 unique local addr
 # ]
+# allowed_ips = []
 
 # [log]
 # file = "isduba.log"

--- a/docs/isdubad-config.md
+++ b/docs/isdubad-config.md
@@ -40,6 +40,27 @@ The configuration consists of the following sections:
   `g`/`G` 1000<sup>3</sup>/1024<sup>3</sup> and none for bytes.
 - `anonymous_event_logging`: Indicates that the event logging of the document
   workflow life cycle should be stored with no user. Defaults to `false`.
+- `allowed_ports`: Is a list of ports and port ranges the source manager and the aggregator
+  are allowed to contact.
+  Defaults to `[80, 443]`. Ranges may be passed as tuples like `[[0, 65535]]`.
+  Mixed entry types as `[80, 8080, [443, 444]]` are possible.
+- `block_loopback`: Is a bool value to block connecting to loopback devices
+  in source manager and aggregator handling. Defaults to `true`.
+- `blocked_ranges`: Is a list of IP ranges which the source manager and the aggregator
+  handling are not allowed to access. Defaults to:
+  ```
+  [
+  	"127.0.0.0/8",    # IPv4 loopback
+	"10.0.0.0/8",     # RFC1918
+	"172.16.0.0/12",  # RFC1918
+	"192.168.0.0/16", # RFC1918
+	"169.254.0.0/16", # RFC3927 link-local
+	"::1/128",        # IPv6 loopback
+	"fe80::/10",      # IPv6 link-local
+	"fc00::/7"        # IPv6 unique local addr
+  ]
+  ```
+  Configuring this will replace this preset.
 
 ### <a name="section_log"></a> Section `[log]` Logging
 

--- a/docs/isdubad-config.md
+++ b/docs/isdubad-config.md
@@ -61,6 +61,8 @@ The configuration consists of the following sections:
   ]
   ```
   Configuring this will replace this preset.
+- `allowed_ips`: Is a list of IPs which are allowed to overrule `blocked_ranges`.
+  This list is empty by default.
 
 ### <a name="section_log"></a> Section `[log]` Logging
 

--- a/pkg/aggregators/cache.go
+++ b/pkg/aggregators/cache.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/ISDuBA/ISDuBA/internal/cache"
+	"github.com/ISDuBA/ISDuBA/pkg/config"
 	"github.com/ISDuBA/ISDuBA/pkg/sources"
 	"github.com/gocsaf/csaf/v3/csaf"
 )
@@ -47,7 +48,7 @@ func newCache(timeout time.Duration) *Cache {
 }
 
 // GetAggregator fetches a cached aggregator.
-func (c *Cache) GetAggregator(url string) (*CachedAggregator, error) {
+func (c *Cache) GetAggregator(url string, cfg *config.Config) (*CachedAggregator, error) {
 	if !strings.HasSuffix(url, "/aggregator.json") {
 		return nil, errors.New("invalid aggregator url")
 	}
@@ -59,7 +60,9 @@ func (c *Cache) GetAggregator(url string) (*CachedAggregator, error) {
 		return nil, err
 	}
 	req.Header.Add("User-Agent", sources.UserAgent)
-	client := &http.Client{}
+	client := &http.Client{
+		Transport: cfg.General.Transport(),
+	}
 	if c.timeout > 0 {
 		client.Timeout = c.timeout
 	}

--- a/pkg/aggregators/manager.go
+++ b/pkg/aggregators/manager.go
@@ -31,14 +31,14 @@ type Manager struct {
 
 	done bool
 	fns  chan func(*Manager)
-	cfg  *config.Aggregators
+	cfg  *config.Config
 	db   *database.DB
 }
 
 // NewManager creates a new aggregators manager.
-func NewManager(cfg *config.Aggregators, db *database.DB) *Manager {
+func NewManager(cfg *config.Config, db *database.DB) *Manager {
 	return &Manager{
-		Cache: newCache(cfg.Timeout),
+		Cache: newCache(cfg.Aggregators.Timeout),
 		fns:   make(chan func(*Manager)),
 		cfg:   cfg,
 		db:    db,
@@ -47,7 +47,7 @@ func NewManager(cfg *config.Aggregators, db *database.DB) *Manager {
 
 // Run runs the aggregators manager.
 func (m *Manager) Run(ctx context.Context) {
-	ticker := time.NewTicker(m.cfg.UpdateInterval)
+	ticker := time.NewTicker(m.cfg.Aggregators.UpdateInterval)
 	defer ticker.Stop()
 	cacheTicker := time.NewTicker(holdingDuration)
 	defer cacheTicker.Stop()
@@ -114,7 +114,7 @@ func (m *Manager) refresh(ctx context.Context) {
 	fetch := func() {
 		defer wg.Done()
 		for agg := range toFetch {
-			cagg, err := m.Cache.GetAggregator(agg.url)
+			cagg, err := m.Cache.GetAggregator(agg.url, m.cfg)
 			if err != nil {
 				slog.Warn("fetching aggregator failed", "url", agg.url, "err", err)
 				continue

--- a/pkg/config/block.go
+++ b/pkg/config/block.go
@@ -69,6 +69,11 @@ func (g *General) blockedIP(ip net.IP) bool {
 	}
 	for _, blocked := range g.BlockedRanges {
 		if blocked.Contains(ip) {
+			for _, allowed := range g.AllowedIPs {
+				if allowed.Equal(ip) {
+					return false
+				}
+			}
 			return true
 		}
 	}

--- a/pkg/config/block.go
+++ b/pkg/config/block.go
@@ -1,0 +1,130 @@
+// This file is Free Software under the Apache-2.0 License
+// without warranty, see README.md and LICENSES/Apache-2.0.txt for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: 2024 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+// Software-Engineering: 2024 Intevation GmbH <https://intevation.de>
+
+package config
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"strconv"
+	"syscall"
+	"time"
+)
+
+// PortRange is a range of ports.
+type PortRange [2]int
+
+// IPRange represents a net address range.
+type IPRange struct {
+	*net.IPNet
+}
+
+// UnmarshalTOML implements [toml.Unmarshaler].
+func (pr *PortRange) UnmarshalTOML(data any) error {
+	switch v := data.(type) {
+	case int64:
+		(*pr)[0], (*pr)[1] = int(v), int(v)
+	case []any:
+		if len(v) != 2 {
+			return errors.New("invalid length")
+		}
+		a, ok1 := v[0].(int64)
+		b, ok2 := v[1].(int64)
+		if !ok1 || !ok2 {
+			return errors.New("invalid range type")
+		}
+		(*pr)[0], (*pr)[1] = int(min(a, b)), int(max(a, b))
+	default:
+		return fmt.Errorf("unsupported type: %T", data)
+	}
+	return nil
+}
+
+// Contains checks if a given port is in the range.
+func (pr PortRange) Contains(port int) bool {
+	return pr[0] <= port && port <= pr[1]
+}
+
+// UnmarshalText implements [encoding.TextUnmarshaler].
+func (br *IPRange) UnmarshalText(text []byte) error {
+	cidr := string(text)
+	_, blocked, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return err
+	}
+	br.IPNet = blocked
+	return nil
+}
+
+func (g *General) blockedIP(ip net.IP) bool {
+	if g.BlockLoopback && (ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast()) {
+		return true
+	}
+	for _, blocked := range g.BlockedRanges {
+		if blocked.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *General) allowedPort(port int) bool {
+	for _, r := range g.AllowedPorts {
+		if r.Contains(port) {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *General) controlDialing(_, address string, _ syscall.RawConn) error {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return err
+	}
+	// Check if the port is allowed
+	if len(g.AllowedPorts) > 0 {
+		p, err := strconv.Atoi(port)
+		if err != nil {
+			return fmt.Errorf("invalid port: %q", host)
+		}
+		if !g.allowedPort(p) {
+			return fmt.Errorf("port %d is not an allowed port", p)
+		}
+	}
+	// Check if the IP is blocked.
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return fmt.Errorf("invalid IP: %q", host)
+	}
+	if g.blockedIP(ip) {
+		return errors.New("accessing address is not allowed")
+	}
+	return nil
+}
+
+// Transport returns an [http.DefaultTransport] like [http.Transport] with
+// an installed dialing control to limit access to the configured constraints.
+func (g *General) Transport() *http.Transport {
+	// This mainly an http.DefaultTransport with a dialer control.
+	return &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Control:   g.controlDialing,
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -161,6 +161,7 @@ type General struct {
 	AllowedPorts          []PortRange `toml:"allowed_ports"`
 	BlockLoopback         bool        `toml:"block_loopback"`
 	BlockedRanges         []IPRange   `toml:"blocked_ranges"`
+	AllowedIPs            []net.IP    `toml:"allowed_ips"`
 }
 
 // Log are the config options for the logging.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -341,6 +341,7 @@ func Load(file string) (*Config, error) {
 			AllowedPorts:          nil,
 			BlockLoopback:         defaultBlockLoopback,
 			BlockedRanges:         nil,
+			AllowedIPs:            nil,
 		},
 		Log: Log{
 			File:   defaultLogFile,

--- a/pkg/sources/keys.go
+++ b/pkg/sources/keys.go
@@ -38,7 +38,8 @@ func (m *Manager) openPGPKeys(source *source) (*crypto.KeyRing, error) {
 		return keys, nil
 	}
 	keys, _ := crypto.NewKeyRing(nil)
-	cpmd := m.pmdCache.pmd(source.url, m.cfg.Sources.Timeout)
+	//cpmd := m.pmdCache.pmd(source.url, m.cfg.Sources.Timeout)
+	cpmd := m.pmdCache.pmd(source.url, m.cfg)
 	if !cpmd.Valid() {
 		// Try again soon.
 		m.keysCache.SetWithExpiration(source.id, keys, holdingPMDsDuration)

--- a/pkg/sources/keys.go
+++ b/pkg/sources/keys.go
@@ -38,7 +38,6 @@ func (m *Manager) openPGPKeys(source *source) (*crypto.KeyRing, error) {
 		return keys, nil
 	}
 	keys, _ := crypto.NewKeyRing(nil)
-	//cpmd := m.pmdCache.pmd(source.url, m.cfg.Sources.Timeout)
 	cpmd := m.pmdCache.pmd(source.url, m.cfg)
 	if !cpmd.Valid() {
 		// Try again soon.

--- a/pkg/sources/manager.go
+++ b/pkg/sources/manager.go
@@ -550,7 +550,7 @@ func (m *Manager) Subscriptions(urls []string) []SourceSubscriptions {
 	}
 	// Resolving external PMDs is too time consuming for the
 	// manager run loop. So do it before.
-	rps.resolve(m.pmdCache, m.cfg.Sources.Timeout)
+	rps.resolve(m.pmdCache, m.cfg)
 
 	// We can subscribe a source more than once.
 	sources := make(map[string][]int64, len(urlIDs))
@@ -1081,7 +1081,7 @@ func (m *Manager) RemoveFeed(feedID int64) error {
 
 // PMD returns the provider metadata from the given url.
 func (m *Manager) PMD(url string) *CachedProviderMetadata {
-	return m.pmdCache.pmd(url, m.cfg.Sources.Timeout)
+	return m.pmdCache.pmd(url, m.cfg)
 }
 
 // updater collects updates so that only the first update on

--- a/pkg/sources/sources.go
+++ b/pkg/sources/sources.go
@@ -451,7 +451,6 @@ func (s *source) wait() *rate.Limiter {
 }
 
 func (s *source) httpClient(m *Manager) *http.Client {
-	client := http.Client{}
 	var tlsConfig tls.Config
 
 	if s.secure != nil {
@@ -464,12 +463,12 @@ func (s *source) httpClient(m *Manager) *http.Client {
 		tlsConfig.Certificates = s.tlsCertificates
 	}
 
+	transport := m.cfg.General.Transport()
+	transport.TLSClientConfig = &tlsConfig
+
+	client := http.Client{Transport: transport}
 	if m.cfg.Sources.Timeout > 0 {
 		client.Timeout = m.cfg.Sources.Timeout
-	}
-
-	client.Transport = &http.Transport{
-		TLSClientConfig: &tlsConfig,
 	}
 	return &client
 }

--- a/pkg/web/aggregators.go
+++ b/pkg/web/aggregators.go
@@ -38,7 +38,7 @@ type argumentedAggregator struct {
 
 func (c *Controller) aggregatorProxy(ctx *gin.Context) {
 	url := ctx.Query("url")
-	ca, err := c.am.Cache.GetAggregator(url)
+	ca, err := c.am.Cache.GetAggregator(url, c.cfg)
 	if err != nil {
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
@@ -135,7 +135,7 @@ func (c *Controller) viewAggregator(ctx *gin.Context) {
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	ca, err := c.am.Cache.GetAggregator(url)
+	ca, err := c.am.Cache.GetAggregator(url, c.cfg)
 	if err != nil {
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return


### PR DESCRIPTION
Resolves #680 

This PR add support to limit the HTTP(S) access of the source manager (handling PMDs, feed indices and advisory downloads) and aggregators.

As these components are intended to load content from remote hosts there is a risk to use these
as e.g. service scanning devices in form of blind Server-Side Request Forgery (SSRF).

To minimize this effect four new configuration parameters are introduced.

1. `allowed_ports` is a list of ports that are allowed to be contacted. This defaults to the port `80` and `443`.
2.  `block_loopback` enables blocking access to loopback devices. This defaults to `true`.
3. `blocked_ranges` is a list of IP sub nets to which access will be blocked. The default protects typical local sub nets:
     -  `127.0.0.0/8`        IPv4 loopback                                    
     -  `10.0.0.0/8`          RFC1918                                          
     -  `172.16.0.0/12`    RFC1918                                          
     - `192.168.0.0/16`   RFC1918                                          
     -  `169.254.0.0/16`  RFC3927 link-local                               
     - `::1/128`                 IPv6 loopback                                    
     - `fe80::/10`              IPv6 link-local                                  
     - `fc00::/7`                 IPv6 unique local addr
4. `allowed_ips`. This is list is checked if an IP is blocked by an entry of `blocked_ranges` to punch in specific holes. By default this list is empty.