### PR TITLE
Statistics: Delay requests when user selects dates and abort old requests

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -14,6 +14,7 @@
         "chart.js": "^4.4.6",
         "chartjs-adapter-moment": "^1.0.1",
         "chroma-js": "^3.1.2",
+        "debounce": "^2.2.0",
         "dompurify": "^3.2.0",
         "jwt-decode": "^4.0.0",
         "marked": "^15.0.1",
@@ -2307,6 +2308,18 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/debounce": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-2.2.0.tgz",
+      "integrity": "sha512-Xks6RUDLZFdz8LIdR6q0MTH44k7FikOmnh5xkSjMig6ch45afc8sjTjRQf3P6ax8dMgcQrYO/AR2RGWURrruqw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/debug": {

--- a/client/package.json
+++ b/client/package.json
@@ -59,6 +59,7 @@
     "chart.js": "^4.4.6",
     "chartjs-adapter-moment": "^1.0.1",
     "chroma-js": "^3.1.2",
+    "debounce": "^2.2.0",
     "dompurify": "^3.2.0",
     "jwt-decode": "^4.0.0",
     "marked": "^15.0.1",

--- a/client/src/lib/request.ts
+++ b/client/src/lib/request.ts
@@ -44,7 +44,7 @@ const requestData = async (
 export const request = async (
   path: string,
   requestMethod: string,
-  formData?: FormData | string,
+  formData?: FormData | string | undefined,
   abortController?: AbortController
 ): Promise<HttpResponse> => {
   try {
@@ -83,6 +83,12 @@ export const request = async (
     }
     return { error: `${response.status}`, content: content, ok: false };
   } catch (error: any) {
+    if (error.name === "AbortError") {
+      return {
+        error: error.name,
+        ok: false
+      };
+    }
     if (/fetch/.test(error)) {
       return {
         error: "600",


### PR DESCRIPTION
Otherwise, when the user uses the scroll wheel to choose the month/year of a date and is not scrolling fast enough one request per month/year is made.

With this commit requests also are aborted if new ones are made. In the end these changes lead to less load for the backend.

This PR affects only the selection of `from` and `to` and fixes #688 . Notice the new dependency. For testing it is required to run `npm install`.