### PR TITLE
Cleaning feed logs

### DIFF
--- a/docs/example_isdubad.toml
+++ b/docs/example_isdubad.toml
@@ -83,6 +83,7 @@
 # timeout = "30s"
 # default_age = "17520h"
 # checking = "2h"
+# keep_feed_logs = "2232h"
 
 # [remote_validator]
 # url = ""

--- a/docs/isdubad-config.md
+++ b/docs/isdubad-config.md
@@ -145,6 +145,9 @@ Valid values for `tlps` are the [Traffic Light Protocol](https://en.wikipedia.or
 - `timeout`: How long should be waited for HTTP responses in sources manager? Defaults to `"30s"`.
 - `default_age`: The default maximum age of the downloaded documents. A value of 0 means that there is no limit. Defaults to `"17520h"`, i.e. 2 years.
 - `checking`: Time interval of re-checking the sources for changes. Defaults to `"2h"`.
+- `keep_feed_logs`: Time interval to keep the feed log entries. Defaults to `"2232h"` 3 * 31 * 24 hours ~ 3 month.
+   Setting this to a duration less or equal zero (e.g. `"0s"`) disables the removal of feed log entries.
+   The database is checked three times an hour if entries are outdated.
 
 ### <a name="section_remote_validator"></a> Section `[remote_validator]` Remote validator
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -124,6 +124,7 @@ const (
 	defaultSourcesAge            = 17520 * time.Hour
 	defaultSourcesAESKey         = ""
 	defaultSourcesChecking       = 2 * time.Hour
+	defaultKeepFeedLogs          = 3 * 31 * 24 * time.Hour
 )
 
 const (
@@ -229,6 +230,7 @@ type Sources struct {
 	DefaultAge        time.Duration         `toml:"default_age"`
 	AESKey            string                `toml:"aes_key"`
 	Checking          time.Duration         `toml:"checking"`
+	KeepFeedLogs      time.Duration         `toml:"keep_feed_logs"`
 }
 
 // ForwardTarget are the config options for the forward target.
@@ -397,6 +399,7 @@ func Load(file string) (*Config, error) {
 			SignatureCheck:    defaultSourcesSignatureCheck,
 			DefaultAge:        defaultSourcesAge,
 			Checking:          defaultSourcesChecking,
+			KeepFeedLogs:      defaultKeepFeedLogs,
 		},
 		Forwarder: Forwarder{
 			UpdateInterval: defaultForwarderUpdateInterval,
@@ -514,6 +517,7 @@ func (cfg *Config) fillFromEnv() error {
 		envStore{"ISDUBA_SOURCES_DEFAULT_AGE", storeDuration(&cfg.Sources.DefaultAge)},
 		envStore{"ISDUBA_SOURCES_AES_KEY", storeString(&cfg.Sources.AESKey)},
 		envStore{"ISDUBA_SOURCES_CHECKING", storeDuration(&cfg.Sources.Checking)},
+		envStore{"ISDUBA_SOURCES_KEEP_FEED_LOGS", storeDuration(&cfg.Sources.KeepFeedLogs)},
 		envStore{"ISDUBA_REMOTE_VALIDATOR_URL", storeString(&cfg.RemoteValidator.URL)},
 		envStore{"ISDUBA_REMOTE_VALIDATOR_CACHE", storeString(&cfg.RemoteValidator.Cache)},
 		envStore{"ISDUBA_CLIENT_KEYCLOAK_URL", storeString(&cfg.Client.KeycloakURL)},

--- a/pkg/sources/manager.go
+++ b/pkg/sources/manager.go
@@ -55,8 +55,12 @@ func (InvalidArgumentError) Is(target error) bool {
 	return ok
 }
 
-// refreshDuration is the fallback duration for feeds to be checked for refresh.
-const refreshDuration = time.Minute
+const (
+	// refreshDuration is the fallback duration for feeds to be checked for refresh.
+	refreshDuration = time.Minute
+	// logCleaningDuration is the interval to remove out-dated log entries.
+	logCleaningDuration = 20 * time.Minute
+)
 
 type downloadJob struct {
 	l location
@@ -84,7 +88,8 @@ type Manager struct {
 	usedSlots int
 	uniqueID  int64
 
-	blockSourceChecking bool
+	blockSourceChecking  bool
+	blockFeedLogCleaning bool
 }
 
 // SourceUpdateResult is return by UpdateSource.
@@ -363,6 +368,9 @@ func (m *Manager) Run(ctx context.Context) {
 	defer refreshTicker.Stop()
 	checkingTicker := time.NewTicker(m.cfg.Sources.Checking)
 	defer checkingTicker.Stop()
+	logCleaningTicker := time.NewTicker(logCleaningDuration)
+	defer logCleaningTicker.Stop()
+
 out:
 	for !m.done {
 		m.pmdCache.Cleanup()
@@ -377,11 +385,45 @@ out:
 			break out
 		case <-checkingTicker.C:
 			m.checkSources()
+		case <-logCleaningTicker.C:
+			m.cleanFeedLogs(ctx)
 		case <-refreshTicker.C:
 		}
 	}
 	close(m.jobs)
 	wg.Wait()
+}
+
+func (m *Manager) enableFeedLogCleaning(context.Context) {
+	m.blockFeedLogCleaning = false
+}
+
+func (m *Manager) cleanFeedLogs(ctx context.Context) {
+	// Check if feed log cleaning is forbidden.
+	if m.cfg.Sources.KeepFeedLogs <= 0 {
+		return
+	}
+	// Check if we are already cleaning the logs.
+	if m.blockFeedLogCleaning {
+		return
+	}
+	// Prevent stacking calls.
+	m.blockFeedLogCleaning = true
+	go func() {
+		// Re-enable log cleaning.
+		defer func() { m.fns <- (*Manager).enableFeedLogCleaning }()
+		const deleteSQL = `DELETE FROM feed_logs ` +
+			`WHERE time < current_timestamp - $1`
+		if err := m.db.Run(
+			ctx,
+			func(ctx context.Context, conn *pgxpool.Conn) error {
+				_, err := conn.Exec(ctx, deleteSQL, m.cfg.Sources.KeepFeedLogs)
+				return err
+			}, 0,
+		); err != nil {
+			slog.Error("Cleaning feed logs failed", "err", err)
+		}
+	}()
 }
 
 type prefetchedPMD struct {


### PR DESCRIPTION
Resolves #697

This PR adds  a configuration variable `keep_feed_logs` defaulting to ~3 months (3*31 days).
Feed log entries older than this value will be removed from the database every 20minutes.
Setting this value to zero or less will deactivate the removal.