### PR TITLE
Show only log entries which are in keeping range

### DIFF
--- a/pkg/sources/manager.go
+++ b/pkg/sources/manager.go
@@ -803,6 +803,12 @@ func (m *Manager) FeedLog(
 		cond.WriteByte(')')
 	}
 
+	// Ignore entries before keeping cut-off.
+	if keepFeedLogs := m.cfg.Sources.KeepFeedLogs; keepFeedLogs > 0 {
+		fmt.Fprintf(&cond, " AND time >= current_timestamp - $%d::interval", len(args)+1)
+		args = append(args, keepFeedLogs)
+	}
+
 	var cntSQL string
 	var cntArgs []any
 


### PR DESCRIPTION
As the feed log cleanup runs only every 20minutes it could be possible that the endpoints may return entries which are still there but should be treated as 'gone'.

This PR reduced the consequences of this effect by delivering only entries which are in the keeping interval.