### PR TITLE
Fix: Restrict roles that cannot request events from viewing the events tab

### DIFF
--- a/client/src/lib/Search/Overview.svelte
+++ b/client/src/lib/Search/Overview.svelte
@@ -201,17 +201,19 @@
           clearSearch();
         }}>Documents</Button
       >
-      <Button
-        size="xs"
-        color="light"
-        class={`h-7 py-1 text-xs ${query.queryType === SEARCHTYPES.EVENT ? "bg-gray-200 hover:bg-gray-100 dark:bg-gray-600 dark:hover:bg-gray-700" : ""}`}
-        on:click={() => {
-          query.queryType = SEARCHTYPES.EVENT;
-          query.columns = SEARCHPAGECOLUMNS.EVENT;
-          query.orders = ["-time"];
-          clearSearch();
-        }}>Events</Button
-      >
+      {#if appStore.isEditor() || appStore.isReviewer() || appStore.isAuditor()}
+        <Button
+          size="xs"
+          color="light"
+          class={`h-7 py-1 text-xs ${query.queryType === SEARCHTYPES.EVENT ? "bg-gray-200 hover:bg-gray-100 dark:bg-gray-600 dark:hover:bg-gray-700" : ""}`}
+          on:click={() => {
+            query.queryType = SEARCHTYPES.EVENT;
+            query.columns = SEARCHPAGECOLUMNS.EVENT;
+            query.orders = ["-time"];
+            clearSearch();
+          }}>Events</Button
+        >
+      {/if}
     </ButtonGroup>
   {/if}
 </div>

--- a/client/src/lib/Search/Overview.svelte
+++ b/client/src/lib/Search/Overview.svelte
@@ -201,7 +201,7 @@
           clearSearch();
         }}>Documents</Button
       >
-      {#if appStore.isEditor() || appStore.isReviewer() || appStore.isAuditor()}
+      {#if appStore.isEditor() || appStore.isReviewer() || appStore.isAdmin() || appStore.isAuditor()}
         <Button
           size="xs"
           color="light"


### PR DESCRIPTION
closes https://github.com/ISDuBA/ISDuBA/issues/504

Admin-role is planned to be able to view events, but currently can't. 

Commit d3fa000047efa090ef0abf848c079d85e8fcda25 enables admins to view events, even if it causes an error for now. -> https://github.com/ISDuBA/ISDuBA/pull/702 solves this error