### PR TITLE
Feat: Reenable recent changes query for admin on dashboard

### DIFF
--- a/client/src/lib/Dashboard/EventQuery.svelte
+++ b/client/src/lib/Dashboard/EventQuery.svelte
@@ -138,7 +138,7 @@
   });
 </script>
 
-{#if $appStore.app.isUserLoggedIn && (appStore.isEditor() || appStore.isReviewer() || appStore.isAuditor())}
+{#if $appStore.app.isUserLoggedIn && (appStore.isEditor() || appStore.isReviewer() || appStore.isAuditor() || appStore.isAdmin())}
   <div class="flex flex-col gap-4 md:w-[46%] md:max-w-[46%]">
     <SectionHeader title={storedQuery.description}></SectionHeader>
     <div class="grid grid-cols-[repeat(auto-fit,_minmax(200pt,_1fr))] gap-6">


### PR DESCRIPTION
Due to https://github.com/ISDuBA/ISDuBA/pull/702, admins can now properly use the recent changes query too so there is no longer  a need to hide them. (Requires https://github.com/ISDuBA/ISDuBA/pull/702)