### PR TITLE
Demand TLP if imported with a publisher context.

### DIFF
--- a/pkg/models/import.go
+++ b/pkg/models/import.go
@@ -339,7 +339,11 @@ func ImportDocumentData(
 		return 0, errors.New("missing /document/tracking/id")
 	}
 
-	if pstlps != nil && (!tlpOk || !pstlps.Allowed(publisher, TLP(tlp))) {
+	if pstlps != nil && !tlpOk {
+		return 0, errors.New("missing /document/distribution/tlp/label")
+	}
+
+	if pstlps != nil && !pstlps.Allowed(publisher, TLP(tlp)) {
 		return 0, ErrNotAllowed
 	}
 


### PR DESCRIPTION
Resolves #499

When an import is done with an publisher context `document/distribution/tlp/label` has to be in the document.