### PR TITLE
Markdown autodocs

### DIFF
--- a/.github/workflows/generate-markdown.yml
+++ b/.github/workflows/generate-markdown.yml
@@ -1,0 +1,28 @@
+# This file is Free Software under the Apache-2.0 License
+# without warranty, see README.md and LICENSES/Apache-2.0.txt for details.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: 2024 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+# Software-Engineering: 2024 Intevation GmbH <https://intevation.de>
+
+name: generate-markdown
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "main"
+      - "markdown-autodocs"
+  pull_request:
+    branches:
+      - "main"
+jobs:
+  auto-update-readme:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v2
+        - name: Markdown autodocs
+          uses: dineshsonachalam/markdown-autodocs@v1.0.4
+          with:
+            output_file_paths: '[./README.md, ./docs/*.md]'

--- a/docs/scripts/README.md
+++ b/docs/scripts/README.md
@@ -12,7 +12,7 @@ A collection of scripts which allows to set up ISDuBA on a Ubuntu 24.04 setup an
 some important setup-steps.
 
 ## [installall.sh](https://github.com/ISDuBA/ISDuBA/blob/main/docs/scripts/installall.sh)
-This script will install git if needed and download the ISDuBA repository in the current directory unless it already exists, in which case it will update it.
+This script will download the ISDuBA repository in the current directory unless it already exists, in which case it will update it.
 Then it will call the setup.sh script that calls all other scripts to set up a testing environment.
 
 installall.sh can be downloaded via:
@@ -28,8 +28,8 @@ Then you can make it executable (e.g. via chmod) and use it to set up the testin
 ```
 Usage: installall.sh [OPTIONS]
 where OPTIONS:
-  -h, --help                       show this help text (optional)
-  -b, --branch=name                set up ISDuBA on branch 'name' instead of main (optional)
+  -h, --help                       show this help text and exit script (optional)
+  -b, --branch=name                set up on branch 'name' instead of main (optional)
   -k, --keycloakRunning            signal the script that there is a keycloak running on port 8080 (optional)
 ```
 

--- a/docs/scripts/setup.sh
+++ b/docs/scripts/setup.sh
@@ -47,6 +47,9 @@ cd ..
 
 ./installisduba.sh # build the isdubad and bulkimporter tools
 
-ISDUBA_DB_MIGRATE=true ./../../cmd/isdubad/isdubad -c ../../isduba.toml # migrate the database so it is up-to-date
+cd ../..
+
+# migrate the database so it is up-to-date
+ISDUBA_DB_MIGRATE=true ./cmd/isdubad/isdubad -c ./isduba.toml
 
 echo "All set up!"

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -22,9 +22,12 @@ Initially there is a migration needed to configure the database
 by starting isdubad with the `ISDUBA_DB_MIGRATE` environment variable
 set to true or by adjusting the toml-configuration file, e.g.
 
+<!-- MARKDOWN-AUTO-DOCS:START (CODE:src=../docs/scripts/setup.sh&lines=53-53) -->
+<!-- The below code snippet is automatically added from ../docs/scripts/setup.sh -->
 ```sh
-ISDUBA_DB_MIGRATE=true ./cmd/isdubad/isdubad -c isduba.toml
+ISDUBA_DB_MIGRATE=true ./cmd/isdubad/isdubad -c ./isduba.toml
 ```
+<!-- MARKDOWN-AUTO-DOCS:END -->
 
 Create additional users via [createUsers script.](./scripts/keycloak/createUsers.sh) A list of users created by the setup scripts can be found in [the users.txt.](./developer/users.txt)
 


### PR DESCRIPTION
- don't mention `git` explicit because developers can look into the scripts for the details
- update usage of install script
- adjust parts of the scripts so it can be used in the docs via autodocs