### PR TITLE
fix: Make QueryTable name and description columns use text-wrap

### DIFF
--- a/client/src/lib/Queries/QueryTable.svelte
+++ b/client/src/lib/Queries/QueryTable.svelte
@@ -181,10 +181,12 @@
                 {/if}
               </TableBodyCell>
               <TableBodyCell {tdClass}>
-                <div class="text-wrap"><span class="columnName">{query.name ?? "-"}</span></div>
+                <div class="text-wrap break-all">
+                  <span class="columnName">{query.name ?? "-"}</span>
+                </div>
               </TableBodyCell>
               <TableBodyCell {tdClass}
-                ><div class="text-wrap">{query.description ?? "-"}</div></TableBodyCell
+                ><div class="text-wrap break-all">{query.description ?? "-"}</div></TableBodyCell
               >
               <TableBodyCell {tdClass}>
                 <CCheckbox

--- a/client/src/lib/Queries/QueryTable.svelte
+++ b/client/src/lib/Queries/QueryTable.svelte
@@ -181,9 +181,11 @@
                 {/if}
               </TableBodyCell>
               <TableBodyCell {tdClass}>
-                <span class="columnName">{query.name ?? "-"}</span>
+                <div class="text-wrap"><span class="columnName">{query.name ?? "-"}</span></div>
               </TableBodyCell>
-              <TableBodyCell {tdClass}>{query.description ?? "-"}</TableBodyCell>
+              <TableBodyCell {tdClass}
+                ><div class="text-wrap">{query.description ?? "-"}</div></TableBodyCell
+              >
               <TableBodyCell {tdClass}>
                 <CCheckbox
                   on:change={() => {


### PR DESCRIPTION
Previously, setting long titles or descriptions for queries would cause them to be displayed inline and cause the columns in question to expand to the width of the longest entry. The table could therefore flow out of the page, even with bigger screen sizes.

This commit causes long names and descriptions to wrap if they get too long.