### PR TITLE
Cleanup domain socket at shutdown

### DIFF
--- a/docs/isdubad-config.md
+++ b/docs/isdubad-config.md
@@ -83,6 +83,7 @@ The configuration consists of the following sections:
 
 - `host`: Interface the web server listens on. Defaults to `"localhost"`.
 If the value starts with a slash (`/`) it is assumed to serve on an unix domain socket.
+In this case all appearance of `{port}` in ths `host` string are replaced by the `port` number.
 - `port`: Port the web server listens on. Defaults to `8081`.
 - `gin_mode`: Mode the Gin middleware is running in. Defaults to `"release"`.
 - `static`: Folder to be served under **<http://host:port/>**. Defaults to `"web"`.


### PR DESCRIPTION
This PR shuts down the isdubad server properly if a KILLTERM signal is send from systemd.
It furthermore removes the created socket file at shutdown.
The port is interpolated into the host path in case of the use of domain sockets.

Contributes to #725