### PR TITLE
Feat: Add important docs into the dist tarball

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,4 +52,8 @@ dist: build_isdubad build_client
 	cp cmd/isdubad/isdubad dist/
 	mkdir -p dist/web
 	cp -r web/* dist/web
+	mkdir -p dist/docs
+	cp -r docs/*.md dist/docs
+	cp -r docs/*.svg dist/docs
+	cp -r docs/*.toml dist/docs
 	cd dist/ ; tar -cvmlzf $(DISTDIR)-gnulinux-amd64.tar.gz *


### PR DESCRIPTION
When building the docs (not the scripts etc.) now are also included into the tar archive