### PR TITLE
Allow to user other filenames for the config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,8 @@ go.work
 cmd/bulkimport/bulkimport
 cmd/isdubad/isdubad
 *.log
-isduba-bsi.toml
+*.toml
+!docs/example_isduba.toml
 
 
 # Client


### PR DESCRIPTION
Since not only the BSI will be using this application we should allow other filenames for the config without users having to fear to commit the config by accident.