### PR TITLE
Fix query selection detection

### DIFF
--- a/client/src/lib/Search/Overview.svelte
+++ b/client/src/lib/Search/Overview.svelte
@@ -23,7 +23,7 @@
   let searchTerm: string | null;
   let advisoryTable: any;
   let advancedSearch = false;
-  let selectedCustomQuery: any;
+  let selectedCustomQuery: boolean;
   let queryString: any;
   // let searchqueryTimer: any = null;
 
@@ -47,13 +47,13 @@
     advisoryTable.fetchData();
   };
 
-  $: if (selectedCustomQuery < 0) {
+  $: if (!selectedCustomQuery) {
     setQueryBack();
   }
 
   const triggerSearch = async () => {
     if (!advancedSearch) {
-      if (selectedCustomQuery < 0) {
+      if (!selectedCustomQuery) {
         query.query = searchTerm ? `"${searchTerm}" search ${searchColumnName} as` : "";
       } else {
         query.query = `${query.queryReset} ${searchTerm ? `"${searchTerm}" search ${searchColumnName} as and` : ""}`;
@@ -74,7 +74,7 @@
       query.columns = query.columns.filter((c) => {
         return c !== searchColumnName;
       });
-      if (selectedCustomQuery < 0) {
+      if (!selectedCustomQuery) {
         query.query = searchTerm || "";
       } else {
         query.query = `${query.queryReset} ${searchTerm ? searchTerm + " and" : ""}`;
@@ -121,7 +121,7 @@
     advisoryTable.fetchData();
   }}
   {queryString}
-  bind:selectedIndex={selectedCustomQuery}
+  bind:selectedQuery={selectedCustomQuery}
 ></Queries>
 <div class="mb-3 flex">
   <div class="flex w-2/3 flex-row">
@@ -161,7 +161,7 @@
       <Toggle bind:checked={advancedSearch} class="ml-3">Advanced</Toggle>
     </div>
   </div>
-  {#if selectedCustomQuery < 0}
+  {#if !selectedCustomQuery}
     <ButtonGroup class="ml-auto h-7">
       <Button
         size="xs"

--- a/client/src/lib/Search/Queries.svelte
+++ b/client/src/lib/Search/Queries.svelte
@@ -30,7 +30,8 @@
     }
     return 0;
   });
-  export let selectedIndex = -2;
+  let selectedIndex = -2;
+  export let selectedQuery: boolean = false;
   export let queryString: any;
   let ignoredQueries: Query[] = [];
   let errorMessage: ErrorDetails | null = null;
@@ -83,6 +84,7 @@
           currentQueryTitle = query.name;
           if (query) {
             dispatch("querySelected", query);
+            selectedQuery = true;
           }
         } else {
           selectQuery(index);
@@ -94,13 +96,15 @@
   let currentQueryTitle: string | undefined;
 
   const selectQuery = (index: number) => {
-    if (selectedIndex == index || index == -1) {
+    if (selectedIndex === index || index === -1) {
       selectedIndex = -1;
       currentQueryTitle = undefined;
+      selectedQuery = false;
     } else {
       selectedIndex = index;
       dispatch("querySelected", sortedQueries[selectedIndex]);
       currentQueryTitle = sortedQueries[selectedIndex].name;
+      selectedQuery = true;
     }
   };
 </script>


### PR DESCRIPTION
If a query from the dashboard was selected, the type selection button was not hidden. This fixes it by correctly setting the state if the query was specified via URL parameter.

Closes #752