### PR TITLE
Fix: pass basePath to Score component

### DIFF
--- a/client/src/lib/Advisories/CSAFWebview/vulnerabilities/vulnerability/Vulnerability.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/vulnerabilities/vulnerability/Vulnerability.svelte
@@ -100,7 +100,7 @@
         <Remediations {vulnerability} {basePath} />
       {/if}
       {#if vulnerability.scores}
-        <Scores {vulnerability} />
+        <Scores {vulnerability} {basePath} />
       {/if}
       {#if vulnerability.threats}
         <Threats {vulnerability} />

--- a/client/src/lib/Advisories/CSAFWebview/vulnerabilities/vulnerability/scores/Scores.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/vulnerabilities/vulnerability/scores/Scores.svelte
@@ -15,6 +15,7 @@
   import ProductStatusValueList from "../productStatus/ProductStatusValueList.svelte";
   import type { Vulnerability } from "$lib/pmdTypes";
   export let vulnerability: Vulnerability;
+  export let basePath = "";
 </script>
 
 <Collapsible header="Scores" level={4}>
@@ -29,7 +30,7 @@
         {/if}
         <div />
         {#if score.products}
-          <ProductStatusValueList label="Product IDs" values={score.products} />
+          <ProductStatusValueList label="Product IDs" values={score.products} {basePath} />
         {/if}
       </Collapsible>
     {/each}


### PR DESCRIPTION
This fixes a bug where clicking on Vulnerabilities -> Scores -> Score x -> Product IDs results in a 404.

Closes #765