### PR TITLE
Remove progress bar for `Loading/Queued`

### DIFF
--- a/client/src/lib/Sources/FeedView.svelte
+++ b/client/src/lib/Sources/FeedView.svelte
@@ -30,14 +30,14 @@
     let loadingHeader = headersEdit.find((header) => header.label == "Loading/Queued");
     if (loadingHeader) {
       if (showProgress) {
-        loadingHeader.progressDuration = shortLoadInterval;
+        // loadingHeader.progressDuration = shortLoadInterval;
       } else {
         loadingHeader.progressDuration = undefined;
       }
     }
   }
 
-  const shortLoadInterval = 5;
+  // const shortLoadInterval = 5;
 
   let headers: TableHeader[] = [
     {
@@ -62,7 +62,7 @@
 
   let headersEdit: TableHeader[] = [
     ...headers,
-    { label: "Loading/Queued", attribute: "stats", progressDuration: shortLoadInterval },
+    { label: "Loading/Queued", attribute: "stats" },
     { label: "Logs", attribute: "logs" }
   ];
 

--- a/client/src/lib/Sources/Overview.svelte
+++ b/client/src/lib/Sources/Overview.svelte
@@ -111,8 +111,7 @@
         },
         {
           label: "Loading/Queued",
-          attribute: "stats",
-          progressDuration: shortLoadInterval
+          attribute: "stats"
         },
         {
           label: "Imported (last 24h)",

--- a/client/src/lib/Sources/SourceEditor.svelte
+++ b/client/src/lib/Sources/SourceEditor.svelte
@@ -357,26 +357,19 @@
         <div class="grid w-full grid-cols-[max-content_max-content_max-content] gap-x-4 text-sm">
           <DescriptionList tag="dt" {dtClass}>Loading</DescriptionList>
           <DescriptionList tag="dt" dtClass={dtClass + " mr-1"}>Queued</DescriptionList>
-          <DescriptionList tag="dt" dtClass={dtClass + " mr-1"}>Imported (last 24h)</DescriptionList
-          >
-          <div class="col-span-2 mb-1 mt-1 h-1 min-h-1">
-            <div class="progressmeter">
-              <span class="w-full"
-                ><span
-                  style="animation-duration: {shortLoadInterval}s"
-                  class="infiniteprogress bg-primary-500"
-                ></span></span
-              >
-            </div>
-          </div>
-          <div class="mb-1 mt-1 h-1 min-h-1">
-            <div class="progressmeter">
-              <span class="w-full"
-                ><span
-                  style="animation-duration: {shortLoadInterval * longLoadMultiplier}s"
-                  class="infiniteprogress bg-primary-500"
-                ></span></span
-              >
+          <div>
+            <DescriptionList tag="dt" dtClass={dtClass + " mr-1"}
+              >Imported (last 24h)</DescriptionList
+            >
+            <div class="mb-1 mt-1 h-1 min-h-1">
+              <div class="progressmeter">
+                <span class="w-full"
+                  ><span
+                    style="animation-duration: {shortLoadInterval * longLoadMultiplier}s"
+                    class="infiniteprogress bg-primary-500"
+                  ></span></span
+                >
+              </div>
             </div>
           </div>
           <DescriptionList tag="dd" {ddClass}>{source.stats.downloading}</DescriptionList>


### PR DESCRIPTION
This progress bar moves too fast, which may irritate users. Removing this bar until a better solution is found.