### PR TITLE
Add logo to login page

### DIFF
--- a/client/src/lib/Login/Login.svelte
+++ b/client/src/lib/Login/Login.svelte
@@ -76,7 +76,13 @@
 
 <div class="flex h-screen items-center justify-center">
   <div class="flex w-96 flex-col gap-4">
-    <div class="inline-flex flex-row"><Heading class="mb-2">ISDuBA</Heading><DarkMode /></div>
+    <div class="inline-flex flex-row">
+      <Heading class="mb-2 flex items-center gap-4">
+        <img class="h-10" src="favicon.svg" alt="Icon of ISDuBA" aria-hidden="true" />
+        <span>ISDuBA</span>
+      </Heading>
+      <DarkMode />
+    </div>
     <Card>
       <div class="flex flex-col gap-4">
         <P class="flex flex-col"


### PR DESCRIPTION
The sidebar is not always visible so it's better to also show the logo on the `/login` page.