### PR TITLE
Dashboard: Show changes sources next to queries

### DIFF
--- a/client/src/lib/Dashboard/Dashboard.svelte
+++ b/client/src/lib/Dashboard/Dashboard.svelte
@@ -82,10 +82,10 @@
         <EventQuery storedQuery={query}></EventQuery>
       {/if}
     {/each}
+    <SourceEvents></SourceEvents>
   </div>
   <ErrorMessage error={loadQueryError}></ErrorMessage>
   <ErrorMessage error={loadIgnoredError}></ErrorMessage>
-  <SourceEvents></SourceEvents>
   <div class="mb-8 flex w-full max-w-[96%] flex-col gap-4 2xl:w-[46%]">
     <ImportStats updateIntervalInMinutes={10}></ImportStats>
   </div>


### PR DESCRIPTION
Before, the "Changed sources" on the dashboard were *always* below the other queries. Now they are next to them if there is enough space.
