### PR TITLE
Fix layout problems

### DIFF
--- a/client/src/lib/Search/Toolbox.svelte
+++ b/client/src/lib/Search/Toolbox.svelte
@@ -17,7 +17,7 @@
   $: docB = $appStore.app.diff.docB;
 </script>
 
-<div class={`sticky bottom-0 left-0 flex flex-col items-start justify-center`}>
+<div class={`sticky bottom-0 left-0 flex translate-y-6 flex-col items-start justify-center`}>
   <div class="flex">
     <Button
       on:click={appStore.toggleToolbox}

--- a/client/src/routes/+page.svelte
+++ b/client/src/routes/+page.svelte
@@ -290,7 +290,7 @@
   <div>
     <SideNav></SideNav>
   </div>
-  <main class="flex max-h-screen w-full flex-col overflow-auto bg-white p-6 pb-0 dark:bg-gray-800">
+  <main class="flex max-h-screen w-full flex-col overflow-auto bg-white p-6 dark:bg-gray-800">
     {#if $appStore.app.userManager}
       <Router {routes} on:conditionsFailed={conditionsFailed} />
     {/if}


### PR DESCRIPTION
When you open a source on a screen with low height and scroll to the bottom where is not space after the last text so it seems that you can scroll further down but you cannot:
![layout](https://github.com/user-attachments/assets/29186c10-ee30-4bbc-9aad-da4209554367)

This PR re-adds padding at the bottom of the main content in the window. The removal was a workaround so the positioning of the diff box could work but now I found a different solution.
