### PR TITLE
Coverage: Set logging level to "info"

### DIFF
--- a/client/playwright.config.ts
+++ b/client/playwright.config.ts
@@ -49,7 +49,7 @@ const config: PlaywrightTestConfig = {
       "monocart-reporter",
       {
         name: "Monocart Reporter test report",
-        logging: "debug",
+        logging: "info",
         outputFile: "./test-results/monocart-report/index.html",
 
         coverage: {


### PR DESCRIPTION
This will remove the source maps from the coverage report. See https://github.com/cenfun/monocart-reporter/issues/165#issuecomment-2592805714.