### PR TITLE
fix: fix misspelled workflow status

### DIFF
--- a/pkg/database/query/parser.go
+++ b/pkg/database/query/parser.go
@@ -732,7 +732,7 @@ func (*Parser) pushCmp(st *stack, et exprType) {
 
 var validWorkflows = []string{
 	"new", "read", "assessing",
-	"review", "archive", "delete",
+	"review", "archived", "delete",
 }
 
 func parseWorkflow(s string) string {


### PR DESCRIPTION
Change should harmonize the spelling of the workflow status "archived". This solves the #847 