### PR TITLE
Make links in advisory view clickable

### DIFF
--- a/client/src/lib/Advisories/CSAFWebview/KeyValue.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/KeyValue.svelte
@@ -44,7 +44,15 @@
         {:else}
           <TableBodyRow color="custom"
             ><TableBodyCell tdClass={cellStyle}>{key}</TableBodyCell>
-            <TableBodyCell tdClass={cellStyle}>{values[index]}</TableBodyCell>
+            <TableBodyCell tdClass={cellStyle}>
+              {#if values[index].startsWith("https://")}
+                <a class="underline" href={values[index]}>
+                  <i class="bx bx-link"></i>{values[index]}
+                </a>
+              {:else}
+                {values[index]}
+              {/if}
+            </TableBodyCell>
           </TableBodyRow>
         {/if}
       {/each}

--- a/client/src/lib/Advisories/CSAFWebview/general/General.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/general/General.svelte
@@ -54,7 +54,11 @@
       <div class={cellStyleKey}>Publisher name</div>
       <div class={cellStyleValue}>{publisherName}</div>
       <div class={cellStyleKey}>Publisher namespace</div>
-      <div class={cellStyleValue}>{publisherNamespace}</div>
+      <div class={cellStyleValue}>
+        <a href={publisherNamespace} class="underline">
+          <i class="bx bx-link"></i>{publisherNamespace}
+        </a>
+      </div>
       {#if publisherContactDetails}
         <div class={cellStyleKey}>Publisher contact details</div>
         <div class={cellStyleValue}>{publisherContactDetails}</div>
@@ -81,7 +85,10 @@
         {#if $appStore.webview.doc?.aggregateSeverity.namespace}
           <div class={cellStyleKey}>Aggregate severity namespace</div>
           <div class={cellStyleValue}>
-            <span>{$appStore.webview.doc?.aggregateSeverity.namespace}</span>
+            <a href={$appStore.webview.doc?.aggregateSeverity.namespace} class="underline">
+              <i class="bx bx-link"></i>
+              <span>{$appStore.webview.doc?.aggregateSeverity.namespace}</span>
+            </a>
           </div>
         {/if}
       {/if}

--- a/client/src/lib/Advisories/CSAFWebview/references/References.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/references/References.svelte
@@ -24,7 +24,8 @@
             <TableBodyCell tdClass={cellStyle}>{reference.category}</TableBodyCell>
             <TableBodyCell tdClass={cellStyle}
               ><p class="mb-2">{reference.summary}</p>
-              <p><i class="bx bx-link"></i>{reference.url}</p></TableBodyCell
+              <a class="underline" href={reference.url}><i class="bx bx-link"></i>{reference.url}</a
+              ></TableBodyCell
             >
             <TableBodyCell></TableBodyCell>
           </TableBodyRow>


### PR DESCRIPTION
Closes #799.

This PR makes almost all links clickable. "Publisher contact details" is one exception because it can be used for links but also other information.