### PR TITLE
Show if source is active

### DIFF
--- a/client/src/lib/Sources/Aggregators/SourceContent.svelte
+++ b/client/src/lib/Sources/Aggregators/SourceContent.svelte
@@ -14,9 +14,13 @@
   import { tdClass } from "$lib/Table/defaults";
   import FeedBulletPoint from "./FeedBulletPoint.svelte";
   import { appStore } from "$lib/store";
+  import { onMount } from "svelte";
+  import { fetchSource } from "../source";
 
   export let source: SourceInfo;
   export let entry: AggregatorEntry;
+
+  let isActive: undefined | boolean;
 
   const sortFeeds = (a: FeedInfo, b: FeedInfo) => {
     if (a.highlight && !b.highlight) {
@@ -26,6 +30,19 @@
     }
     return 0;
   };
+
+  const findOutIfActive = async () => {
+    if (source.id) {
+      const result = await fetchSource(source.id);
+      if (result.ok) {
+        isActive = result.value.active;
+      }
+    }
+  };
+
+  onMount(() => {
+    findOutIfActive();
+  });
 </script>
 
 <div class="mb-2 flex items-center gap-2 text-sm text-black dark:text-white">
@@ -33,6 +50,13 @@
     <i class="bx bx-git-repo-forked text-lg"></i>
   {/if}
   {source.name}
+  {#if source.name !== "Not configured"}
+    {#if isActive}
+      <i class="bx bxs-circle"></i>
+    {:else if isActive === false}
+      <i class="bx bx-circle"></i>
+    {/if}
+  {/if}
   {#if entry.feedsSubscribed === 0 && appStore.isSourceManager()}
     <Button href={`/#/sources/new/${encodeURIComponent(entry.url)}`} color="primary" size="xs">
       <i class="bx bx-plus"></i>


### PR DESCRIPTION
Closes #809.

With this PR the indicator which is used in the source list at `Sources` now is also used for sources inside the aggregator view:

![active-source](https://github.com/user-attachments/assets/443d9cd3-ff08-444c-a007-aae5260fe02d)
