### PR TITLE
Upgrade go build container

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -19,7 +19,7 @@ COPY Makefile Makefile
 RUN make build_client
 
 
-FROM library/golang:1.23-alpine AS server
+FROM library/golang:1.24-alpine AS server
 RUN apk update && apk add --no-cache make
 # This required to download from https locations, like CSAF trusted provider or CSAF aggregator
 RUN apk add -U --no-cache ca-certificates && update-ca-certificates


### PR DESCRIPTION
The new version is needed to build the application.