### PR TITLE
Ensure same hash if order changed

### DIFF
--- a/pkg/aggregators/manager.go
+++ b/pkg/aggregators/manager.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"crypto/sha1"
 	"log/slog"
+	"sort"
 	"sync"
 	"time"
 
@@ -67,7 +68,10 @@ func (m *Manager) Run(ctx context.Context) {
 
 func aggregatorChecksum(cagg *CachedAggregator) []byte {
 	hash := sha1.New()
-	for _, url := range cagg.SourceURLs() {
+	urls := cagg.SourceURLs()
+	// Ensure same hash on different order
+	sort.Strings(urls)
+	for _, url := range urls {
 		hash.Write([]byte(url))
 	}
 	return hash.Sum(nil)

--- a/pkg/aggregators/manager.go
+++ b/pkg/aggregators/manager.go
@@ -14,7 +14,7 @@ import (
 	"context"
 	"crypto/sha1"
 	"log/slog"
-	"sort"
+	"slices"
 	"sync"
 	"time"
 
@@ -70,7 +70,7 @@ func aggregatorChecksum(cagg *CachedAggregator) []byte {
 	hash := sha1.New()
 	urls := cagg.SourceURLs()
 	// Ensure same hash on different order
-	sort.Strings(urls)
+	slices.Sort(urls)
 	for _, url := range urls {
 		hash.Write([]byte(url))
 	}


### PR DESCRIPTION
This is required when an aggregator changes the order of the listed urls.