### PR TITLE
Add lock to aggregator toggle

### DIFF
--- a/client/src/lib/Sources/Aggregators/AggregatorViewer.svelte
+++ b/client/src/lib/Sources/Aggregators/AggregatorViewer.svelte
@@ -348,27 +348,29 @@
   };
 
   const toggleAggregatorView = async (aggregator: Aggregator) => {
-    if (aggregator.id === undefined) {
-      return;
-    }
-    if (aggregatorData.get(aggregator.id)) {
-      aggregatorData.delete(aggregator.id);
-      aggregatorData = aggregatorData;
-      saveAggregatorExpand();
-      return;
-    }
-    loadingAggregators = true;
-    const resp = await fetchAggregatorData(aggregator.url);
-    loadingAggregators = false;
-    if (resp.ok) {
-      aggregatorData.set(aggregator.id, parseAggregatorData(resp.value));
-      aggregatorData = aggregatorData;
-      aggregatorMetaData.set(aggregator.id, resp.value);
-      aggregatorMetaData = aggregatorMetaData;
-      saveAggregatorExpand();
-    } else {
-      aggregatorError = resp.error;
-    }
+    await navigator.locks.request("toggleAgg", async () => {
+      if (aggregator.id === undefined) {
+        return;
+      }
+      if (aggregatorData.get(aggregator.id)) {
+        aggregatorData.delete(aggregator.id);
+        aggregatorData = aggregatorData;
+        saveAggregatorExpand();
+        return;
+      }
+      loadingAggregators = true;
+      const resp = await fetchAggregatorData(aggregator.url);
+      loadingAggregators = false;
+      if (resp.ok) {
+        aggregatorData.set(aggregator.id, parseAggregatorData(resp.value));
+        aggregatorData = aggregatorData;
+        aggregatorMetaData.set(aggregator.id, resp.value);
+        aggregatorMetaData = aggregatorMetaData;
+        saveAggregatorExpand();
+      } else {
+        aggregatorError = resp.error;
+      }
+    });
   };
 
   const removeAggregator = async (id: number) => {


### PR DESCRIPTION
If toggle is called multiple times and the previous request is slower than next, it will result in a race condition, where the state is not correctly set. The locking can be improved by introducing a separate lock per aggregator.

Closes #863