### PR TITLE
Correctly resolve url if base has no trailing slash

### DIFF
--- a/pkg/sources/indices.go
+++ b/pkg/sources/indices.go
@@ -39,7 +39,7 @@ func (fi *feedIndex) rolieLocations(r io.Reader) ([]location, error) {
 			return fmt.Errorf("invalid href: %v", href)
 		}
 		if !u.IsAbs() {
-			u = fi.base.JoinPath(u.Path)
+			u = joinURL(fi.base, u)
 		}
 		*store = u
 		return nil
@@ -141,7 +141,7 @@ func (fi *feedIndex) directoryLocations(r io.Reader) ([]location, error) {
 			return nil, fmt.Errorf("column 2 in line %d is not a valid RFC3339 time: %w", lineNo, err)
 		}
 		if !doc.IsAbs() {
-			doc = fi.base.JoinPath(doc.Path)
+			doc = joinURL(fi.base, doc)
 		}
 		// Apply age filter
 		if fi.age != nil && updated.Before(cut) {

--- a/pkg/sources/indices.go
+++ b/pkg/sources/indices.go
@@ -39,7 +39,7 @@ func (fi *feedIndex) rolieLocations(r io.Reader) ([]location, error) {
 			return fmt.Errorf("invalid href: %v", href)
 		}
 		if !u.IsAbs() {
-			u = fi.base.ResolveReference(u)
+			u = fi.base.JoinPath(u.Path)
 		}
 		*store = u
 		return nil
@@ -141,7 +141,7 @@ func (fi *feedIndex) directoryLocations(r io.Reader) ([]location, error) {
 			return nil, fmt.Errorf("column 2 in line %d is not a valid RFC3339 time: %w", lineNo, err)
 		}
 		if !doc.IsAbs() {
-			doc = fi.base.ResolveReference(doc)
+			doc = fi.base.JoinPath(doc.Path)
 		}
 		// Apply age filter
 		if fi.age != nil && updated.Before(cut) {

--- a/pkg/sources/keys.go
+++ b/pkg/sources/keys.go
@@ -68,7 +68,7 @@ func (m *Manager) openPGPKeys(source *source) (*crypto.KeyRing, error) {
 			slog.Warn("Invalid OpenPGP url", "url", *key.URL, "err", err)
 			continue
 		}
-		u = base.ResolveReference(u)
+		u = base.JoinPath(u.Path)
 		res, err := source.httpGet(client, m, u.String())
 		if err != nil {
 			slog.Warn(

--- a/pkg/sources/keys.go
+++ b/pkg/sources/keys.go
@@ -68,7 +68,9 @@ func (m *Manager) openPGPKeys(source *source) (*crypto.KeyRing, error) {
 			slog.Warn("Invalid OpenPGP url", "url", *key.URL, "err", err)
 			continue
 		}
-		u = base.JoinPath(u.Path)
+		if !u.IsAbs() {
+			u = joinURL(base, u)
+		}
 		res, err := source.httpGet(client, m, u.String())
 		if err != nil {
 			slog.Warn(

--- a/pkg/sources/util.go
+++ b/pkg/sources/util.go
@@ -10,6 +10,7 @@ package sources
 
 import (
 	"fmt"
+	"net/url"
 	"regexp"
 )
 
@@ -44,4 +45,14 @@ func AsRegexps(s []string) ([]*regexp.Regexp, error) {
 		slice = append(slice, re)
 	}
 	return slice, nil
+}
+
+// joinURL joins the two URLs while preserving the query and fragment part of the latter.
+func joinURL(baseURL *url.URL, relativeURL *url.URL) *url.URL {
+	u := baseURL.JoinPath(relativeURL.Path)
+	u.RawQuery = relativeURL.RawQuery
+	u.RawFragment = relativeURL.RawFragment
+	// Enforce https, this is required if the base url was only a domain
+	u.Scheme = "https"
+	return u
 }


### PR DESCRIPTION
If the URL was previously https://example.com/abc, the abc part was ignored.

Closes #912.