### PR TITLE
Use the correct log level name

### DIFF
--- a/client/src/lib/Sources/source.ts
+++ b/client/src/lib/Sources/source.ts
@@ -75,7 +75,7 @@ const logLevels = [
   { value: LogLevel.default, name: "Default" },
   { value: LogLevel.error, name: "Errors" },
   { value: LogLevel.info, name: "Info" },
-  { value: LogLevel.warn, name: "Errors and warnings" },
+  { value: LogLevel.warn, name: "Warning" },
   { value: LogLevel.debug, name: "Debug (verbose)" }
 ];
 

--- a/client/src/lib/Sources/source.ts
+++ b/client/src/lib/Sources/source.ts
@@ -74,8 +74,8 @@ type Feed = {
 const logLevels = [
   { value: LogLevel.default, name: "Default" },
   { value: LogLevel.error, name: "Errors" },
-  { value: LogLevel.info, name: "Info" },
   { value: LogLevel.warn, name: "Warning" },
+  { value: LogLevel.info, name: "Info" },
   { value: LogLevel.debug, name: "Debug (verbose)" }
 ];
 


### PR DESCRIPTION
This reverts the custom log level naming, which resulted in more confusion.