### PR TITLE
Use integer type for timestamps

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -262,8 +262,8 @@ type Client struct {
 	KeycloakURL      string        `toml:"keycloak_url" json:"keycloak_url"`
 	KeycloakRealm    string        `toml:"keycloak_realm" json:"keycloak_realm"`
 	KeycloakClientID string        `toml:"keycloak_client_id" json:"keycloak_client_id"`
-	UpdateInterval   time.Duration `toml:"update_interval" json:"update_interval"`
-	IdleTimeout      time.Duration `toml:"idle_timeout" json:"idle_timeout"`
+	UpdateInterval   time.Duration `toml:"update_interval" json:"update_interval" swaggertype:"integer"`
+	IdleTimeout      time.Duration `toml:"idle_timeout" json:"idle_timeout" swaggertype:"integer"`
 }
 
 // Config are all the configuration options.

--- a/pkg/web/docs/docs.go
+++ b/pkg/web/docs/docs.go
@@ -1761,6 +1761,11 @@ const docTemplate = `{
                         "in": "formData"
                     },
                     {
+                        "type": "integer",
+                        "name": "age",
+                        "in": "formData"
+                    },
+                    {
                         "type": "boolean",
                         "name": "attention",
                         "in": "formData"
@@ -2060,19 +2065,19 @@ const docTemplate = `{
                     },
                     {
                         "enum": [
-                            1,
                             0,
                             1,
                             2,
-                            3
+                            3,
+                            1
                         ],
                         "type": "integer",
                         "x-enum-varnames": [
-                            "defaultSourcesFeedLogLevel",
                             "DebugFeedLogLevel",
                             "InfoFeedLogLevel",
                             "WarnFeedLogLevel",
-                            "ErrorFeedLogLevel"
+                            "ErrorFeedLogLevel",
+                            "defaultSourcesFeedLogLevel"
                         ],
                         "name": "log_level",
                         "in": "formData"
@@ -2351,6 +2356,11 @@ const docTemplate = `{
                     {
                         "type": "boolean",
                         "name": "active",
+                        "in": "formData"
+                    },
+                    {
+                        "type": "integer",
+                        "name": "age",
                         "in": "formData"
                     },
                     {
@@ -3440,7 +3450,7 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "idle_timeout": {
-                    "$ref": "#/definitions/time.Duration"
+                    "type": "integer"
                 },
                 "keycloak_client_id": {
                     "type": "string"
@@ -3452,25 +3462,25 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "update_interval": {
-                    "$ref": "#/definitions/time.Duration"
+                    "type": "integer"
                 }
             }
         },
         "config.FeedLogLevel": {
             "type": "integer",
             "enum": [
-                1,
                 0,
                 1,
                 2,
-                3
+                3,
+                1
             ],
             "x-enum-varnames": [
-                "defaultSourcesFeedLogLevel",
                 "DebugFeedLogLevel",
                 "InfoFeedLogLevel",
                 "WarnFeedLogLevel",
-                "ErrorFeedLogLevel"
+                "ErrorFeedLogLevel",
+                "defaultSourcesFeedLogLevel"
             ]
         },
         "forwarder.ForwardTarget": {
@@ -3821,29 +3831,6 @@ const docTemplate = `{
                 }
             }
         },
-        "time.Duration": {
-            "type": "integer",
-            "enum": [
-                -9223372036854775808,
-                9223372036854775807,
-                1,
-                1000,
-                1000000,
-                1000000000,
-                60000000000,
-                3600000000000
-            ],
-            "x-enum-varnames": [
-                "minDuration",
-                "maxDuration",
-                "Nanosecond",
-                "Microsecond",
-                "Millisecond",
-                "Second",
-                "Minute",
-                "Hour"
-            ]
-        },
         "web.about.info": {
             "type": "object",
             "properties": {
@@ -3951,7 +3938,7 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "age": {
-                    "$ref": "#/definitions/web.sourceAge"
+                    "type": "integer"
                 },
                 "log_level": {
                     "$ref": "#/definitions/config.FeedLogLevel"
@@ -4036,7 +4023,7 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "keep_feed_time": {
-                    "$ref": "#/definitions/time.Duration"
+                    "type": "integer"
                 }
             }
         },
@@ -4106,7 +4093,7 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "age": {
-                    "$ref": "#/definitions/web.sourceAge"
+                    "type": "integer"
                 },
                 "attention": {
                     "type": "boolean"
@@ -4168,34 +4155,6 @@ const docTemplate = `{
                 "url": {
                     "type": "string",
                     "minLength": 1
-                }
-            }
-        },
-        "web.sourceAge": {
-            "type": "object",
-            "properties": {
-                "time.Duration": {
-                    "type": "integer",
-                    "enum": [
-                        -9223372036854775808,
-                        9223372036854775807,
-                        1,
-                        1000,
-                        1000000,
-                        1000000000,
-                        60000000000,
-                        3600000000000
-                    ],
-                    "x-enum-varnames": [
-                        "minDuration",
-                        "maxDuration",
-                        "Nanosecond",
-                        "Microsecond",
-                        "Millisecond",
-                        "Second",
-                        "Minute",
-                        "Hour"
-                    ]
                 }
             }
         },

--- a/pkg/web/docs/swagger.json
+++ b/pkg/web/docs/swagger.json
@@ -1754,6 +1754,11 @@
                         "in": "formData"
                     },
                     {
+                        "type": "integer",
+                        "name": "age",
+                        "in": "formData"
+                    },
+                    {
                         "type": "boolean",
                         "name": "attention",
                         "in": "formData"
@@ -2053,19 +2058,19 @@
                     },
                     {
                         "enum": [
-                            1,
                             0,
                             1,
                             2,
-                            3
+                            3,
+                            1
                         ],
                         "type": "integer",
                         "x-enum-varnames": [
-                            "defaultSourcesFeedLogLevel",
                             "DebugFeedLogLevel",
                             "InfoFeedLogLevel",
                             "WarnFeedLogLevel",
-                            "ErrorFeedLogLevel"
+                            "ErrorFeedLogLevel",
+                            "defaultSourcesFeedLogLevel"
                         ],
                         "name": "log_level",
                         "in": "formData"
@@ -2344,6 +2349,11 @@
                     {
                         "type": "boolean",
                         "name": "active",
+                        "in": "formData"
+                    },
+                    {
+                        "type": "integer",
+                        "name": "age",
                         "in": "formData"
                     },
                     {
@@ -3433,7 +3443,7 @@
             "type": "object",
             "properties": {
                 "idle_timeout": {
-                    "$ref": "#/definitions/time.Duration"
+                    "type": "integer"
                 },
                 "keycloak_client_id": {
                     "type": "string"
@@ -3445,25 +3455,25 @@
                     "type": "string"
                 },
                 "update_interval": {
-                    "$ref": "#/definitions/time.Duration"
+                    "type": "integer"
                 }
             }
         },
         "config.FeedLogLevel": {
             "type": "integer",
             "enum": [
-                1,
                 0,
                 1,
                 2,
-                3
+                3,
+                1
             ],
             "x-enum-varnames": [
-                "defaultSourcesFeedLogLevel",
                 "DebugFeedLogLevel",
                 "InfoFeedLogLevel",
                 "WarnFeedLogLevel",
-                "ErrorFeedLogLevel"
+                "ErrorFeedLogLevel",
+                "defaultSourcesFeedLogLevel"
             ]
         },
         "forwarder.ForwardTarget": {
@@ -3814,29 +3824,6 @@
                 }
             }
         },
-        "time.Duration": {
-            "type": "integer",
-            "enum": [
-                -9223372036854775808,
-                9223372036854775807,
-                1,
-                1000,
-                1000000,
-                1000000000,
-                60000000000,
-                3600000000000
-            ],
-            "x-enum-varnames": [
-                "minDuration",
-                "maxDuration",
-                "Nanosecond",
-                "Microsecond",
-                "Millisecond",
-                "Second",
-                "Minute",
-                "Hour"
-            ]
-        },
         "web.about.info": {
             "type": "object",
             "properties": {
@@ -3944,7 +3931,7 @@
             "type": "object",
             "properties": {
                 "age": {
-                    "$ref": "#/definitions/web.sourceAge"
+                    "type": "integer"
                 },
                 "log_level": {
                     "$ref": "#/definitions/config.FeedLogLevel"
@@ -4029,7 +4016,7 @@
             "type": "object",
             "properties": {
                 "keep_feed_time": {
-                    "$ref": "#/definitions/time.Duration"
+                    "type": "integer"
                 }
             }
         },
@@ -4099,7 +4086,7 @@
                     "type": "boolean"
                 },
                 "age": {
-                    "$ref": "#/definitions/web.sourceAge"
+                    "type": "integer"
                 },
                 "attention": {
                     "type": "boolean"
@@ -4161,34 +4148,6 @@
                 "url": {
                     "type": "string",
                     "minLength": 1
-                }
-            }
-        },
-        "web.sourceAge": {
-            "type": "object",
-            "properties": {
-                "time.Duration": {
-                    "type": "integer",
-                    "enum": [
-                        -9223372036854775808,
-                        9223372036854775807,
-                        1,
-                        1000,
-                        1000000,
-                        1000000000,
-                        60000000000,
-                        3600000000000
-                    ],
-                    "x-enum-varnames": [
-                        "minDuration",
-                        "maxDuration",
-                        "Nanosecond",
-                        "Microsecond",
-                        "Millisecond",
-                        "Second",
-                        "Minute",
-                        "Hour"
-                    ]
                 }
             }
         },

--- a/pkg/web/sources.go
+++ b/pkg/web/sources.go
@@ -60,7 +60,7 @@ type source struct {
 	StrictMode           *bool          `json:"strict_mode,omitempty" form:"strict_mode"`
 	Secure               *bool          `json:"secure,omitempty" form:"secure"`
 	SignatureCheck       *bool          `json:"signature_check,omitempty" form:"signature_check"`
-	Age                  *sourceAge     `json:"age,omitempty" form:"age"`
+	Age                  *sourceAge     `json:"age,omitempty" form:"age" swaggertype:"primitive,integer"`
 	IgnorePatterns       []string       `json:"ignore_patterns,omitempty" form:"ignore_patterns"`
 	ClientCertPublic     *string        `json:"client_cert_public,omitempty" form:"client_cert_public"`
 	ClientCertPrivate    *string        `json:"client_cert_private,omitempty" form:"client_cert_private"`
@@ -934,7 +934,7 @@ func (c *Controller) defaultMessage(ctx *gin.Context) {
 //	@Router			/sources/feeds/keep [get]
 func (c *Controller) keepFeedTime(ctx *gin.Context) {
 	type keepFeedTimeConfig struct {
-		KeepFeedTime time.Duration `json:"keep_feed_time"`
+		KeepFeedTime time.Duration `json:"keep_feed_time" swaggertype:"integer"`
 	}
 	ctx.JSON(http.StatusOK, keepFeedTimeConfig{KeepFeedTime: c.cfg.Sources.KeepFeedLogs})
 }
@@ -981,7 +981,7 @@ func (c *Controller) defaultSourceConfig(ctx *gin.Context) {
 		StrictMode     bool                `json:"strict_mode"`
 		Secure         bool                `json:"secure"`
 		SignatureCheck bool                `json:"signature_check"`
-		Age            sourceAge           `json:"age"`
+		Age            sourceAge           `json:"age" swaggertype:"primitive,integer"`
 	}
 	cfg := c.cfg.Sources
 	ctx.JSON(http.StatusOK, sourceConfig{


### PR DESCRIPTION
This avoids generating client code that does not accept valid values.