### PR TITLE
Add link to API documentation in client and docs

### DIFF
--- a/client/src/lib/Login/Login.svelte
+++ b/client/src/lib/Login/Login.svelte
@@ -102,6 +102,8 @@
             ISDuBA is Free Software.
             <A href="https://github.com/ISDuBA/" class="underline hover:no-underline"
               >The source code is available on Github.</A
+            ><A href="/swagger/index.html" class="underline hover:no-underline"
+              >ISDuBA API documentation.</A
             ></P
           >
         {/if}
@@ -172,6 +174,11 @@
             </List>
           {/if}
         {/await}
+      </P>
+      <P>
+        <A href="/swagger/index.html" class="underline hover:no-underline"
+          >ISDuBA API documentation</A
+        >
       </P>
     {/if}
     <ErrorMessage error={viewError}></ErrorMessage>

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -15,6 +15,10 @@ export default defineConfig({
       "/api/": {
         target: "http://localhost:8081/",
         changeOrigin: true
+      },
+      "/swagger/": {
+        target: "http://localhost:8081/",
+        changeOrigin: true
       }
     }
   },

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ Decide how to test or setup your own ISDuBA instance.
  2. Want to support the ISDuBA project with your own code? [Here's how to setup a development instance of ISDuBA](#development-setup)
  3. Want to use ISDuBA for yourself or your organization? [Here's how to setup ISDuBA for production](#production-setup)
  4. Having set up an instance of ISDuBA, you can read about what to do now within the [first steps guide](./first_steps.md)
+ 5. Want to use the ISDuBA API? Head over to http://isduba.example.com/swagger/index.html and enjoy the swagger documentation of the interface.
 
 When starting the application, you will be prompted to safe your aes_key. This can be ignored for test or development instances and is further explained in [the aes-keys section of the security considerations documentation](./security_considerations.md#aes-keys).
 


### PR DESCRIPTION
docs: add a note on the api documentation location
login and profile page (logged in): add a direct link to the api documentation

fixes https://github.com/ISDuBA/ISDuBA/issues/956

Login page:

![image](https://github.com/user-attachments/assets/638a6d5c-6644-41f9-b856-bd5e8f4087a2)

Profile page (when logged in):

![image](https://github.com/user-attachments/assets/3970a663-5314-4eeb-9653-0659e1e7efdb)
