### PR TITLE
Fix unused prop warning

### DIFF
--- a/client/src/lib/NotFound.svelte
+++ b/client/src/lib/NotFound.svelte
@@ -7,5 +7,10 @@
  SPDX-FileCopyrightText: 2024 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
  Software-Engineering: 2024 Intevation GmbH <https://intevation.de>
 -->
+<script lang="ts">
+  // Avoid warning of unsued prop
+  // eslint-disable-next-line
+  export let params: any = null;
+</script>
 
 <h1>Not Found</h1>

--- a/client/src/lib/NotFound.svelte
+++ b/client/src/lib/NotFound.svelte
@@ -8,7 +8,7 @@
  Software-Engineering: 2024 Intevation GmbH <https://intevation.de>
 -->
 <script lang="ts">
-  // Avoid warning of unsued prop
+  // Avoid warning of unused prop
   // eslint-disable-next-line
   export let params: any = null;
 </script>


### PR DESCRIPTION
Removes the following warning:
<img width="689" alt="Screenshot 2025-06-27 at 16 30 06" src="https://github.com/user-attachments/assets/b29853d1-d236-4c4e-88bf-8bcd11ce36f5" />
