### PR TITLE
Only load events when allowed

### DIFF
--- a/client/src/lib/Dashboard/EventQuery.svelte
+++ b/client/src/lib/Dashboard/EventQuery.svelte
@@ -132,9 +132,16 @@
   };
 
   onMount(async () => {
-    isLoading = true;
-    await transformDataToActivities();
-    isLoading = false;
+    if (
+      appStore.isEditor() ||
+      appStore.isReviewer() ||
+      appStore.isAuditor() ||
+      appStore.isAdmin()
+    ) {
+      isLoading = true;
+      await transformDataToActivities();
+      isLoading = false;
+    }
   });
 </script>
 


### PR DESCRIPTION
This avoids an error if the user is only source manager.