### PR TITLE
Fix a query order race condition

### DIFF
--- a/client/src/lib/Queries/Overview.svelte
+++ b/client/src/lib/Queries/Overview.svelte
@@ -124,34 +124,36 @@
   };
 
   const cloneQuery = async (query: Query) => {
-    if (!queries) return;
-    isCloning = true;
-    query.name = proposeName(queries, query.name);
-    const response = await createStoredQuery(query);
-    if (!response.ok && response.error) {
-      cloneErrorMessage = getErrorDetails(`Failed to clone query.`, response);
-    } else if (response.ok) {
-      await placeQueriesAtTop([response.content.id]);
-      const queriesBeforeClone = queries;
-      await fetchData();
-      const table = document.getElementById(query.global ? "global-queries" : "personal-queries");
-      if (table) {
-        table.scrollTop = 0;
-        table.scrollIntoView({ behavior: "smooth" });
+    await navigator.locks.request("updateQuery", async () => {
+      if (!queries) return;
+      isCloning = true;
+      query.name = proposeName(queries, query.name);
+      const response = await createStoredQuery(query);
+      if (!response.ok && response.error) {
+        cloneErrorMessage = getErrorDetails(`Failed to clone query.`, response);
+      } else if (response.ok) {
+        await placeQueriesAtTop([response.content.id]);
+        const queriesBeforeClone = queries;
+        await fetchData();
+        const table = document.getElementById(query.global ? "global-queries" : "personal-queries");
+        if (table) {
+          table.scrollTop = 0;
+          table.scrollIntoView({ behavior: "smooth" });
+        }
+        const queriesAfterClone = queries;
+        newQueries = [
+          ...newQueries,
+          ...queriesAfterClone.filter((q) => !queriesBeforeClone.map((q) => q.id).includes(q.id))
+        ];
+        const newQueriesCopy: Query[] = newQueries;
+        setTimeout(() => {
+          newQueries = newQueries.filter((q) => {
+            return !newQueriesCopy.map((q) => q.id).includes(q.id);
+          });
+        }, 5000);
       }
-      const queriesAfterClone = queries;
-      newQueries = [
-        ...newQueries,
-        ...queriesAfterClone.filter((q) => !queriesBeforeClone.map((q) => q.id).includes(q.id))
-      ];
-      const newQueriesCopy: Query[] = newQueries;
-      setTimeout(() => {
-        newQueries = newQueries.filter((q) => {
-          return !newQueriesCopy.map((q) => q.id).includes(q.id);
-        });
-      }, 5000);
-    }
-    isCloning = false;
+      isCloning = false;
+    });
   };
 
   const placeQueriesAtTop = async (queryIDs: number[], global = false) => {

--- a/client/src/lib/Queries/QueryTable.svelte
+++ b/client/src/lib/Queries/QueryTable.svelte
@@ -44,29 +44,31 @@
   let isLoading = false;
 
   const updateQueryOrder = async (queries: Query[]) => {
-    let nodes = columnList.querySelectorAll(".columnName");
-    type Order = {
-      id: number;
-      order: number;
-    };
-    let orders: Order[] = [];
-    let i = 0;
-    for (const node of nodes) {
-      let columnName = node.innerText;
-      let query = queries.find((q) => q.name === columnName);
-      if (query) {
-        orders.push({ id: query.id, order: i });
+    await navigator.locks.request("updateQuery", async () => {
+      let nodes = columnList.querySelectorAll(".columnName");
+      type Order = {
+        id: number;
+        order: number;
+      };
+      let orders: Order[] = [];
+      let i = 0;
+      for (const node of nodes) {
+        let columnName = node.innerText;
+        let query = queries.find((q) => q.name === columnName);
+        if (query) {
+          orders.push({ id: query.id, order: i });
+        }
+        i++;
       }
-      i++;
-    }
 
-    let response = await request(`/api/queries/orders`, "POST", JSON.stringify(orders));
-    if (!response.ok && response.error) {
-      orderErrorMessage = getErrorDetails(`Could not update query order.`, response);
-    }
-    if (response.ok) {
-      push(`/queries/`);
-    }
+      let response = await request(`/api/queries/orders`, "POST", JSON.stringify(orders));
+      if (!response.ok && response.error) {
+        orderErrorMessage = getErrorDetails(`Could not update query order.`, response);
+      }
+      if (response.ok) {
+        push(`/queries/`);
+      }
+    });
   };
 
   const elementDragEventUserQuery = () => {


### PR DESCRIPTION
After a user cloned a query, there is a time window where the client requests the current query data, and the current client side data is stale. When the user changes the stale query order it will conflict with the current data.
This can happen on slow or bad connections.