### PR TITLE
Try the previous page if there are no documents on the current

### DIFF
--- a/client/src/lib/Table/Table.svelte
+++ b/client/src/lib/Table/Table.svelte
@@ -239,6 +239,11 @@
         ({ count, documents } = response.content);
       }
       appStore.setDocuments(documents);
+      // We are outside the range of available documents,
+      // try the previous page
+      if (offset > 0 && count == 0) {
+        await previous();
+      }
     } else if (response.error) {
       error =
         response.error === "400"
@@ -251,31 +256,31 @@
     requestOngoing = false;
   }
 
-  const previous = () => {
+  const previous = async () => {
     if (offset - limit >= 0) {
       offset = offset - limit > 0 ? offset - limit : 0;
       currentPage -= 1;
     }
-    fetchData();
+    await fetchData();
   };
-  const next = () => {
+  const next = async () => {
     if (offset + limit <= count) {
       offset = offset + limit;
       currentPage += 1;
     }
-    fetchData();
+    await fetchData();
   };
 
-  const first = () => {
+  const first = async () => {
     offset = 0;
     currentPage = 1;
-    fetchData();
+    await fetchData();
   };
 
-  const last = () => {
+  const last = async () => {
     offset = (numberOfPages - 1) * limit;
     currentPage = numberOfPages;
-    fetchData();
+    await fetchData();
   };
 
   const switchSort = async (column: string) => {
@@ -292,12 +297,12 @@
     }
     orderBy = orderBy;
     await tick();
-    fetchData();
+    await fetchData();
   };
 
   const onDeleted = async () => {
     await fetchData();
-    first();
+    await first();
   };
 
   $: numberOfPages = Math.ceil(count / limit);


### PR DESCRIPTION
This avoids breaking the navigation when documents are deleted, while the user is on the last page.
on the last page.