### PR TITLE
fix: Prevent errors

### DIFF
--- a/client/src/lib/Advisories/CSAFWebview/producttree/product/ProductNames.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/producttree/product/ProductNames.svelte
@@ -19,6 +19,8 @@
   });
 </script>
 
-{#each productNames as product}
-  <ProductName {product} />
-{/each}
+{#if productNames}
+  {#each productNames as product}
+    <ProductName {product} />
+  {/each}
+{/if}

--- a/client/src/lib/Advisories/CSAFWebview/producttree/productgroup/ProductGroups.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/producttree/productgroup/ProductGroups.svelte
@@ -13,6 +13,8 @@
   export let productGroups: any;
 </script>
 
-{#each productGroups as productGroup}
-  <ProductGroup {productGroup} />
-{/each}
+{#if productGroups}
+  {#each productGroups as productGroup}
+    <ProductGroup {productGroup} />
+  {/each}
+{/if}


### PR DESCRIPTION
Before, there was a case where productNames was false and the application became unresponsive. While at it also prevented the error in ProductGroups.

This doesn't solve the cause of the problem which needs more investigation.