### PR TITLE
Revert "build(deps-dev): bump flowbite from 2.5.2 to 3.1.2 in /client"

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -44,7 +44,7 @@
         "eslint": "^9.28.0",
         "eslint-config-prettier": "^10.1.5",
         "eslint-plugin-svelte": "^2.46.1",
-        "flowbite": "^3.1.2",
+        "flowbite": "^2.5.2",
         "flowbite-svelte": "^0.47.4",
         "husky": "^9.1.7",
         "monocart-reporter": "^2.9.20",
@@ -5001,16 +5001,15 @@
       "license": "ISC"
     },
     "node_modules/flowbite": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/flowbite/-/flowbite-3.1.2.tgz",
-      "integrity": "sha512-MkwSgbbybCYgMC+go6Da5idEKUFfMqc/AmSjm/2ZbdmvoKf5frLPq/eIhXc9P+rC8t9boZtUXzHDgt5whZ6A/Q==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/flowbite/-/flowbite-2.5.2.tgz",
+      "integrity": "sha512-kwFD3n8/YW4EG8GlY3Od9IoKND97kitO+/ejISHSqpn3vw2i5K/+ZI8Jm2V+KC4fGdnfi0XZ+TzYqQb4Q1LshA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.9.3",
-        "flowbite-datepicker": "^1.3.1",
-        "mini-svg-data-uri": "^1.4.3",
-        "postcss": "^8.5.1"
+        "flowbite-datepicker": "^1.3.0",
+        "mini-svg-data-uri": "^1.4.3"
       }
     },
     "node_modules/flowbite-datepicker": {
@@ -5022,18 +5021,6 @@
       "dependencies": {
         "@rollup/plugin-node-resolve": "^15.2.3",
         "flowbite": "^2.0.0"
-      }
-    },
-    "node_modules/flowbite-datepicker/node_modules/flowbite": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/flowbite/-/flowbite-2.5.2.tgz",
-      "integrity": "sha512-kwFD3n8/YW4EG8GlY3Od9IoKND97kitO+/ejISHSqpn3vw2i5K/+ZI8Jm2V+KC4fGdnfi0XZ+TzYqQb4Q1LshA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@popperjs/core": "^2.9.3",
-        "flowbite-datepicker": "^1.3.0",
-        "mini-svg-data-uri": "^1.4.3"
       }
     },
     "node_modules/flowbite-svelte": {
@@ -5050,18 +5037,6 @@
       },
       "peerDependencies": {
         "svelte": "^3.55.1 || ^4.0.0 || ^5.0.0"
-      }
-    },
-    "node_modules/flowbite-svelte/node_modules/flowbite": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/flowbite/-/flowbite-2.5.2.tgz",
-      "integrity": "sha512-kwFD3n8/YW4EG8GlY3Od9IoKND97kitO+/ejISHSqpn3vw2i5K/+ZI8Jm2V+KC4fGdnfi0XZ+TzYqQb4Q1LshA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@popperjs/core": "^2.9.3",
-        "flowbite-datepicker": "^1.3.0",
-        "mini-svg-data-uri": "^1.4.3"
       }
     },
     "node_modules/foreground-child": {

--- a/client/package.json
+++ b/client/package.json
@@ -41,7 +41,7 @@
     "eslint": "^9.28.0",
     "eslint-config-prettier": "^10.1.5",
     "eslint-plugin-svelte": "^2.46.1",
-    "flowbite": "^3.1.2",
+    "flowbite": "^2.5.2",
     "flowbite-svelte": "^0.47.4",
     "husky": "^9.1.7",
     "monocart-reporter": "^2.9.20",


### PR DESCRIPTION
This reverts commit e75c0a15c2190801f013fb13a9c2b5ba74e2521d.
This commit lead to switching between light and dark mode not working, and may have caused other errors we simply didn't find yet. We need to properly check them first. Will lead to reopening of https://github.com/ISDuBA/ISDuBA/issues/977