### PR TITLE
Display error for individual files

### DIFF
--- a/client/src/lib/Sources/DocumentUpload.svelte
+++ b/client/src/lib/Sources/DocumentUpload.svelte
@@ -9,27 +9,27 @@
 -->
 
 <script lang="ts">
-  import { getErrorDetails, type ErrorDetails } from "$lib/Errors/error";
-  import ErrorMessage from "$lib/Errors/ErrorMessage.svelte";
+  import { getErrorDetails } from "$lib/Errors/error";
+  import { type UploadInfo } from "$lib/Sources/source";
   import Upload from "$lib/Upload.svelte";
   import { request } from "$lib/request";
-  import { push } from "svelte-spa-router";
 
-  let uploadError: ErrorDetails | null;
-
-  const uploadDocuments = async (files: FileList) => {
+  const uploadDocuments = async (files: FileList): Promise<UploadInfo[]> => {
+    let uploadInfo = [];
     for (const file of files) {
+      let info: UploadInfo = { success: true };
       const formData = new FormData();
       formData.append("file", file);
       const resp = await request(`/api/documents`, "POST", formData);
       if (resp.error) {
-        uploadError = getErrorDetails(`Could not upload file`, resp);
-        return;
+        info.success = false;
+        let details = getErrorDetails(`Could not upload file`, resp);
+        info.message = `${details.message} ${details.details}`;
       }
+      uploadInfo.push(info);
     }
-    push(`/sources`);
+    return uploadInfo;
   };
 </script>
 
 <Upload upload={uploadDocuments} label="Upload a document"></Upload>
-<ErrorMessage error={uploadError}></ErrorMessage>

--- a/client/src/lib/Sources/source.ts
+++ b/client/src/lib/Sources/source.ts
@@ -100,6 +100,11 @@ type Attention = {
   name: string;
 };
 
+type UploadInfo = {
+  success?: boolean;
+  message?: string;
+};
+
 const fetchAggregatorAttentionList = async (): Promise<Result<Attention[], ErrorDetails>> => {
   const resp = await request(`/api/aggregators/attention`, "GET");
   if (resp.ok) {
@@ -691,6 +696,7 @@ export {
   type Attention,
   LogLevel,
   type Feed,
+  type UploadInfo,
   saveSource,
   saveAggregator,
   updateAggregator,

--- a/client/src/lib/Upload.svelte
+++ b/client/src/lib/Upload.svelte
@@ -9,13 +9,36 @@
 -->
 
 <script lang="ts">
-  import { Button, Card, Fileupload, Label, Listgroup, ListgroupItem } from "flowbite-svelte";
+  import {
+    Button,
+    Card,
+    Fileupload,
+    Label,
+    Listgroup,
+    ListgroupItem,
+    Tooltip
+  } from "flowbite-svelte";
+  import { type UploadInfo } from "$lib/Sources/source";
   export let label;
-  export let upload = (files: FileList) => {
+  export let upload = async (files: FileList): Promise<UploadInfo[]> => {
     // eslint-disable-next-line no-console
-    console.log(files);
+    console.log(files, uploadInfo);
+    return [];
+  };
+
+  export let uploadInfo: UploadInfo[] = [];
+
+  const getColor = (uploadInfo: UploadInfo) => {
+    let success = uploadInfo?.success;
+    if (success !== undefined) {
+      return success ? "text-green-600" : "text-red-600";
+    }
+    return "";
   };
   let files: FileList;
+  $: if (files) {
+    uploadInfo = [];
+  }
 </script>
 
 <Card size="lg">
@@ -26,15 +49,21 @@
       {#if !files}
         <ListgroupItem>No files selected</ListgroupItem>
       {:else}
-        {#each files as file}
-          <ListgroupItem>{file.name}</ListgroupItem>
+        {#each files as file, i}
+          {@const info = uploadInfo[i]}
+          {@const color = getColor(info)}
+          <ListgroupItem class={color}>{file.name}</ListgroupItem>
+
+          {#if info?.message}
+            <Tooltip>{info.message}</Tooltip>
+          {/if}
         {/each}
       {/if}
     </Listgroup>
   </div>
   <Button
-    on:click={() => {
-      upload(files);
+    on:click={async () => {
+      uploadInfo = await upload(files);
     }}
     class="mt-auto ml-auto"
     color="primary">Upload</Button


### PR DESCRIPTION
Don't abort when a single error occurs and display the success status for each individual file.