### PR TITLE
Allow to disable search results

### DIFF
--- a/client/src/lib/Search/Overview.svelte
+++ b/client/src/lib/Search/Overview.svelte
@@ -23,6 +23,7 @@
   let searchTerm: string | null;
   let advisoryTable: any;
   let advancedSearch = false;
+  let searchResults = true;
   let selectedCustomQuery: boolean;
   let queryString: any;
   let defaultQuery: any;
@@ -192,6 +193,9 @@
     <div class="mt-1" title="Define finer grained search queries">
       <Toggle bind:checked={advancedSearch} class="ml-3">Advanced</Toggle>
     </div>
+    <div class="mt-1" title="Toggle if search results should be returned">
+      <Toggle bind:checked={searchResults} class="ml-3">Results</Toggle>
+    </div>
   </div>
   {#if !selectedCustomQuery}
     <ButtonGroup class="ml-auto h-7">
@@ -247,6 +251,7 @@
     query={`${query.query}`}
     orderBy={query.orders}
     bind:this={advisoryTable}
+    {searchResults}
   ></AdvisoryTable>
 {/if}
 

--- a/client/src/lib/Search/Overview.svelte
+++ b/client/src/lib/Search/Overview.svelte
@@ -193,8 +193,8 @@
     <div class="mt-1" title="Define finer grained search queries">
       <Toggle bind:checked={advancedSearch} class="ml-3">Advanced</Toggle>
     </div>
-    <div class="mt-1" title="Toggle if search results should be returned">
-      <Toggle bind:checked={searchResults} class="ml-3">Results</Toggle>
+    <div class="mt-1" title="Show every single time the search term was found">
+      <Toggle bind:checked={searchResults} class="ml-3">Detailed</Toggle>
     </div>
   </div>
   {#if !selectedCustomQuery}

--- a/client/src/lib/Table/Table.svelte
+++ b/client/src/lib/Table/Table.svelte
@@ -64,6 +64,7 @@
   export let tableType: SEARCHTYPES;
   export let orderBy: string[] = ["title"];
   export let defaultOrderBy = ["title"];
+  export let searchResults: boolean;
 
   const tdClass = "whitespace-nowrap relative";
 
@@ -86,6 +87,10 @@
     ((tableType !== SEARCHTYPES.EVENT && appStore.isAdmin()) || tableType === SEARCHTYPES.ADVISORY);
   $: areThereAnyComments =
     tableType === SEARCHTYPES.EVENT && documents?.find((d: any) => d.event === "add_comment");
+
+  $: if (searchResults !== undefined) {
+    fetchData();
+  }
 
   let selectedState: any;
   let dropdownOpen = false;
@@ -217,7 +222,7 @@
     } else {
       const loadAdvisories = tableType === SEARCHTYPES.ADVISORY;
       documentURL = encodeURI(
-        `/api/documents?${queryParam}&advisories=${loadAdvisories}&count=1&orders=${orderBy.join(" ")}&limit=${limit}&offset=${offset}&columns=${fetchColumns.join(" ")}${searchColumn}`
+        `/api/documents?${queryParam}&advisories=${loadAdvisories}&count=1&orders=${orderBy.join(" ")}&limit=${limit}&offset=${offset}&results=${searchResults}&columns=${fetchColumns.join(" ")}${searchColumn}`
       );
     }
 

--- a/internal/database/query/sqlbuilder.go
+++ b/internal/database/query/sqlbuilder.go
@@ -17,12 +17,14 @@ import (
 
 // SQLBuilder helps to construct a SQL query.
 type SQLBuilder struct {
-	WhereClause  string
-	Replacements []any
-	replToIdx    map[string]int
-	Aliases      map[string]string
-	Mode         ParserMode
-	TextTables   bool
+	WhereClause         string
+	Replacements        []any
+	replToIdx           map[string]int
+	Aliases             map[string]string
+	IgnoreFields        map[string]struct{}
+	Mode                ParserMode
+	TextTables          bool
+	ReturnSearchResults bool
 }
 
 // CreateWhere construct a WHERE clause for a given expression.
@@ -50,20 +52,42 @@ func LikeEscape(query string) string {
 }
 
 func (sb *SQLBuilder) searchWhere(e *Expr, b *strings.Builder) {
-	fmt.Fprintf(b, "txt ILIKE $%d",
-		sb.replacementIndex(LikeEscape(e.stringValue))+1)
+	if sb.ReturnSearchResults {
+		fmt.Fprintf(b, "txt ILIKE $%d",
+			sb.replacementIndex(LikeEscape(e.stringValue))+1)
 
-	// We need the text tables to be joined.
-	sb.TextTables = true
+		// We need the text tables to be joined.
+		sb.TextTables = true
 
-	// Handle alias
-	if e.alias == "" {
-		return
+		// Handle alias
+		if e.alias == "" {
+			return
+		}
+		if sb.Aliases == nil {
+			sb.Aliases = map[string]string{}
+		}
+		sb.Aliases[e.alias] = `txt`
+	} else {
+		switch sb.Mode {
+		case AdvisoryMode, DocumentMode:
+			fmt.Fprintf(b, "EXISTS(SELECT 1 FROM unique_texts "+
+				"JOIN documents_texts ON unique_texts.id = documents_texts.txt_id "+
+				"WHERE txt ILIKE $%d "+
+				"AND documents_texts.documents_id = documents.id)", sb.replacementIndex(LikeEscape(e.stringValue))+1)
+		case EventMode:
+			// TODO clarify how to handle event search
+		}
+
+		// Ignore alias for now to avoid breaking change
+		if e.alias == "" {
+			return
+		}
+		if sb.IgnoreFields == nil {
+			sb.IgnoreFields = map[string]struct{}{}
+		}
+		sb.IgnoreFields[e.alias] = struct{}{}
 	}
-	if sb.Aliases == nil {
-		sb.Aliases = map[string]string{}
-	}
-	sb.Aliases[e.alias] = `txt`
+
 }
 
 func (sb *SQLBuilder) mentionedWhere(e *Expr, b *strings.Builder) {
@@ -416,7 +440,7 @@ func (sb *SQLBuilder) CreateOrder(fields []string) (string, error) {
 
 // CreateQuery creates an SQL statement to query the documents
 // table and the associated texts if needed.
-// WARN: Make sure that the iput is vetted against injections.
+// WARN: Make sure that the input is vetted against injections.
 func (sb *SQLBuilder) CreateQuery(
 	fields []string,
 	order string,
@@ -451,6 +475,9 @@ func (sb *SQLBuilder) CreateQuery(
 // projectionsWithCasts joins given projection adding casts if needed.
 func (sb *SQLBuilder) projectionsWithCasts(b *strings.Builder, proj []string) {
 	for i, p := range proj {
+		if _, found := sb.IgnoreFields[p]; found {
+			continue
+		}
 		if i > 0 {
 			b.WriteByte(',')
 		}
@@ -502,6 +529,9 @@ func (sb *SQLBuilder) projectionsWithCasts(b *strings.Builder, proj []string) {
 func (sb *SQLBuilder) CheckProjections(proj []string) error {
 	for _, p := range proj {
 		if _, found := sb.Aliases[p]; found {
+			continue
+		}
+		if _, found := sb.IgnoreFields[p]; found {
 			continue
 		}
 		if !ExistsDocumentColumn(p, sb.Mode) {

--- a/internal/database/query/sqlbuilder.go
+++ b/internal/database/query/sqlbuilder.go
@@ -70,8 +70,8 @@ func (sb *SQLBuilder) searchWhere(e *Expr, b *strings.Builder) {
 	} else {
 		switch sb.Mode {
 		case AdvisoryMode, DocumentMode:
-			fmt.Fprintf(b, "EXISTS(SELECT 1 FROM unique_texts "+
-				"JOIN documents_texts ON unique_texts.id = documents_texts.txt_id "+
+			fmt.Fprintf(b, "EXISTS(SELECT 1 FROM documents_texts "+
+				"JOIN unique_texts ON unique_texts.id = documents_texts.txt_id "+
 				"WHERE txt ILIKE $%d "+
 				"AND documents_texts.documents_id = documents.id)", sb.replacementIndex(LikeEscape(e.stringValue))+1)
 		case EventMode:

--- a/internal/web/advisory.go
+++ b/internal/web/advisory.go
@@ -135,9 +135,9 @@ func (c *Controller) changeStatusAll(ctx *gin.Context, inputs advisoryStates) {
 //	@Description	Changes the status of the specified advisory, if allowed.
 //	@Param			publisher	path	string	true	"Publisher"
 //	@Param			trackingid	path	string	true	"Tracking ID"
-//	@Param			state	path	string	true	"Advisory status"
+//	@Param			state		path	string	true	"Advisory status"
 //	@Produce		json
-//	@Success		200	{object}		models.Success
+//	@Success		200	{object}	models.Success
 //	@Failure		400	{object}	models.Error
 //	@Failure		401
 //	@Failure		403	{object}	models.Error
@@ -158,9 +158,9 @@ func (c *Controller) changeStatus(ctx *gin.Context) {
 //	@Summary		Bulk changes status.
 //	@Description	Changes the status of multiple advisories, if allowed.
 //	@Param			input	body	advisoryStates	true	"Advisory states"
-//	@Accept		json
+//	@Accept			json
 //	@Produce		json
-//	@Success		200	{object}		models.Success
+//	@Success		200	{object}	models.Success
 //	@Failure		400	{object}	models.Error
 //	@Failure		401
 //	@Failure		403	{object}	models.Error

--- a/internal/web/docs/docs.go
+++ b/internal/web/docs/docs.go
@@ -735,6 +735,12 @@ const docTemplate = `{
                         "description": "Offset",
                         "name": "offset",
                         "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Return search results",
+                        "name": "results",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -1260,6 +1266,14 @@ const docTemplate = `{
                             "Reviewer": "Reviewer role",
                             "SourceManager": "Source Manager role"
                         },
+                        "x-enum-descriptions": [
+                            "Admin role",
+                            "Importer role",
+                            "Editor role",
+                            "Reviewer role",
+                            "Auditor role",
+                            "Source Manager role"
+                        ],
                         "x-enum-varnames": [
                             "Admin",
                             "Importer",
@@ -1621,6 +1635,14 @@ const docTemplate = `{
                             "Reviewer": "Reviewer role",
                             "SourceManager": "Source Manager role"
                         },
+                        "x-enum-descriptions": [
+                            "Admin role",
+                            "Importer role",
+                            "Editor role",
+                            "Reviewer role",
+                            "Auditor role",
+                            "Source Manager role"
+                        ],
                         "x-enum-varnames": [
                             "Admin",
                             "Importer",
@@ -1725,6 +1747,12 @@ const docTemplate = `{
                         "description": "Enable statistic",
                         "name": "stats",
                         "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Enable health indicator",
+                        "name": "health",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -1792,6 +1820,11 @@ const docTemplate = `{
                         },
                         "collectionFormat": "csv",
                         "name": "headers",
+                        "in": "formData"
+                    },
+                    {
+                        "type": "boolean",
+                        "name": "healthy",
                         "in": "formData"
                     },
                     {
@@ -2010,6 +2043,12 @@ const docTemplate = `{
                         "description": "Enable statistic",
                         "name": "stats",
                         "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Enable health indicator",
+                        "name": "health",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -2054,6 +2093,11 @@ const docTemplate = `{
                         "required": true
                     },
                     {
+                        "type": "boolean",
+                        "name": "healthy",
+                        "in": "formData"
+                    },
+                    {
                         "type": "integer",
                         "name": "id",
                         "in": "formData"
@@ -2072,6 +2116,7 @@ const docTemplate = `{
                             1
                         ],
                         "type": "integer",
+                        "format": "int32",
                         "x-enum-varnames": [
                             "DebugFeedLogLevel",
                             "InfoFeedLogLevel",
@@ -2310,6 +2355,12 @@ const docTemplate = `{
                         "description": "Enable statistic",
                         "name": "stats",
                         "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Enable health indicator",
+                        "name": "health",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -2390,6 +2441,11 @@ const docTemplate = `{
                         },
                         "collectionFormat": "csv",
                         "name": "headers",
+                        "in": "formData"
+                    },
+                    {
+                        "type": "boolean",
+                        "name": "healthy",
                         "in": "formData"
                     },
                     {
@@ -2549,9 +2605,22 @@ const docTemplate = `{
                         "required": true
                     },
                     {
+                        "type": "integer",
+                        "description": "Source ID",
+                        "name": "health",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
                         "type": "boolean",
                         "description": "Enable statistic",
                         "name": "stats",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Enable health indicator",
+                        "name": "health",
                         "in": "query"
                     }
                 ],
@@ -3468,6 +3537,7 @@ const docTemplate = `{
         },
         "config.FeedLogLevel": {
             "type": "integer",
+            "format": "int32",
             "enum": [
                 0,
                 1,
@@ -3551,6 +3621,17 @@ const docTemplate = `{
                 "ImportDocumentEvent": "ImportDocumentEvent represents a document import.",
                 "StateChangeEvent": "StateChangeEvent represents changing the advisory state."
             },
+            "x-enum-descriptions": [
+                "ImportDocumentEvent represents a document import.",
+                "DeleteDocumentEvent represents a document deletion.",
+                "StateChangeEvent represents changing the advisory state.",
+                "AddSSVCEvent represents the addtion of a SSVC score.",
+                "ChangeSSVCEvent represents the change of a SSVC score.",
+                "DeleteSSVCEvent represents the deletion of a SSVC score.",
+                "AddCommentEvent represents the addition of a comment.",
+                "ChangeCommentEvent represents the change of a comment.",
+                "DeleteCommentEvent represents the deletion of a comment."
+            ],
             "x-enum-varnames": [
                 "ImportDocumentEvent",
                 "DeleteDocumentEvent",
@@ -3649,6 +3730,12 @@ const docTemplate = `{
                 "TLPRed": "TLPRed   represents TLP:RED",
                 "TLPWhite": "TLPWhite represents TLP:WHITE"
             },
+            "x-enum-descriptions": [
+                "TLPWhite represents TLP:WHITE",
+                "TLPGreen represents TLP:GREEN",
+                "TLPAmber represents TLP:AMBER",
+                "TLPRed   represents TLP:RED"
+            ],
             "x-enum-varnames": [
                 "TLPWhite",
                 "TLPGreen",
@@ -3674,6 +3761,14 @@ const docTemplate = `{
                 "ReadWorkflow": "ReadWorkflow represents 'read'.",
                 "ReviewWorkflow": "ReviewWorkflow represents 'review'."
             },
+            "x-enum-descriptions": [
+                "NewWorkflow represents 'new'.",
+                "ReadWorkflow represents 'read'.",
+                "AssessingWorkflow represents 'assessing',",
+                "ReviewWorkflow represents 'review'.",
+                "ArchivedWorkflow represents 'archived'.",
+                "DeleteWorkflow represents 'delete'."
+            ],
             "x-enum-varnames": [
                 "NewWorkflow",
                 "ReadWorkflow",
@@ -3701,6 +3796,14 @@ const docTemplate = `{
                 "Reviewer": "Reviewer role",
                 "SourceManager": "Source Manager role"
             },
+            "x-enum-descriptions": [
+                "Admin role",
+                "Importer role",
+                "Editor role",
+                "Reviewer role",
+                "Auditor role",
+                "Source Manager role"
+            ],
             "x-enum-varnames": [
                 "Admin",
                 "Importer",
@@ -3793,6 +3896,9 @@ const docTemplate = `{
             "properties": {
                 "downloading": {
                     "type": "integer"
+                },
+                "healthy": {
+                    "type": "boolean"
                 },
                 "waiting": {
                     "type": "integer"
@@ -3963,6 +4069,9 @@ const docTemplate = `{
         "web.feed": {
             "type": "object",
             "properties": {
+                "healthy": {
+                    "type": "boolean"
+                },
                 "id": {
                     "type": "integer"
                 },
@@ -4112,6 +4221,9 @@ const docTemplate = `{
                     "items": {
                         "type": "string"
                     }
+                },
+                "healthy": {
+                    "type": "boolean"
                 },
                 "id": {
                     "type": "integer"

--- a/internal/web/docs/swagger.json
+++ b/internal/web/docs/swagger.json
@@ -728,6 +728,12 @@
                         "description": "Offset",
                         "name": "offset",
                         "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Return search results",
+                        "name": "results",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -1253,6 +1259,14 @@
                             "Reviewer": "Reviewer role",
                             "SourceManager": "Source Manager role"
                         },
+                        "x-enum-descriptions": [
+                            "Admin role",
+                            "Importer role",
+                            "Editor role",
+                            "Reviewer role",
+                            "Auditor role",
+                            "Source Manager role"
+                        ],
                         "x-enum-varnames": [
                             "Admin",
                             "Importer",
@@ -1614,6 +1628,14 @@
                             "Reviewer": "Reviewer role",
                             "SourceManager": "Source Manager role"
                         },
+                        "x-enum-descriptions": [
+                            "Admin role",
+                            "Importer role",
+                            "Editor role",
+                            "Reviewer role",
+                            "Auditor role",
+                            "Source Manager role"
+                        ],
                         "x-enum-varnames": [
                             "Admin",
                             "Importer",
@@ -1718,6 +1740,12 @@
                         "description": "Enable statistic",
                         "name": "stats",
                         "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Enable health indicator",
+                        "name": "health",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -1785,6 +1813,11 @@
                         },
                         "collectionFormat": "csv",
                         "name": "headers",
+                        "in": "formData"
+                    },
+                    {
+                        "type": "boolean",
+                        "name": "healthy",
                         "in": "formData"
                     },
                     {
@@ -2003,6 +2036,12 @@
                         "description": "Enable statistic",
                         "name": "stats",
                         "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Enable health indicator",
+                        "name": "health",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -2047,6 +2086,11 @@
                         "required": true
                     },
                     {
+                        "type": "boolean",
+                        "name": "healthy",
+                        "in": "formData"
+                    },
+                    {
                         "type": "integer",
                         "name": "id",
                         "in": "formData"
@@ -2065,6 +2109,7 @@
                             1
                         ],
                         "type": "integer",
+                        "format": "int32",
                         "x-enum-varnames": [
                             "DebugFeedLogLevel",
                             "InfoFeedLogLevel",
@@ -2303,6 +2348,12 @@
                         "description": "Enable statistic",
                         "name": "stats",
                         "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Enable health indicator",
+                        "name": "health",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -2383,6 +2434,11 @@
                         },
                         "collectionFormat": "csv",
                         "name": "headers",
+                        "in": "formData"
+                    },
+                    {
+                        "type": "boolean",
+                        "name": "healthy",
                         "in": "formData"
                     },
                     {
@@ -2542,9 +2598,22 @@
                         "required": true
                     },
                     {
+                        "type": "integer",
+                        "description": "Source ID",
+                        "name": "health",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
                         "type": "boolean",
                         "description": "Enable statistic",
                         "name": "stats",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Enable health indicator",
+                        "name": "health",
                         "in": "query"
                     }
                 ],
@@ -3461,6 +3530,7 @@
         },
         "config.FeedLogLevel": {
             "type": "integer",
+            "format": "int32",
             "enum": [
                 0,
                 1,
@@ -3544,6 +3614,17 @@
                 "ImportDocumentEvent": "ImportDocumentEvent represents a document import.",
                 "StateChangeEvent": "StateChangeEvent represents changing the advisory state."
             },
+            "x-enum-descriptions": [
+                "ImportDocumentEvent represents a document import.",
+                "DeleteDocumentEvent represents a document deletion.",
+                "StateChangeEvent represents changing the advisory state.",
+                "AddSSVCEvent represents the addtion of a SSVC score.",
+                "ChangeSSVCEvent represents the change of a SSVC score.",
+                "DeleteSSVCEvent represents the deletion of a SSVC score.",
+                "AddCommentEvent represents the addition of a comment.",
+                "ChangeCommentEvent represents the change of a comment.",
+                "DeleteCommentEvent represents the deletion of a comment."
+            ],
             "x-enum-varnames": [
                 "ImportDocumentEvent",
                 "DeleteDocumentEvent",
@@ -3642,6 +3723,12 @@
                 "TLPRed": "TLPRed   represents TLP:RED",
                 "TLPWhite": "TLPWhite represents TLP:WHITE"
             },
+            "x-enum-descriptions": [
+                "TLPWhite represents TLP:WHITE",
+                "TLPGreen represents TLP:GREEN",
+                "TLPAmber represents TLP:AMBER",
+                "TLPRed   represents TLP:RED"
+            ],
             "x-enum-varnames": [
                 "TLPWhite",
                 "TLPGreen",
@@ -3667,6 +3754,14 @@
                 "ReadWorkflow": "ReadWorkflow represents 'read'.",
                 "ReviewWorkflow": "ReviewWorkflow represents 'review'."
             },
+            "x-enum-descriptions": [
+                "NewWorkflow represents 'new'.",
+                "ReadWorkflow represents 'read'.",
+                "AssessingWorkflow represents 'assessing',",
+                "ReviewWorkflow represents 'review'.",
+                "ArchivedWorkflow represents 'archived'.",
+                "DeleteWorkflow represents 'delete'."
+            ],
             "x-enum-varnames": [
                 "NewWorkflow",
                 "ReadWorkflow",
@@ -3694,6 +3789,14 @@
                 "Reviewer": "Reviewer role",
                 "SourceManager": "Source Manager role"
             },
+            "x-enum-descriptions": [
+                "Admin role",
+                "Importer role",
+                "Editor role",
+                "Reviewer role",
+                "Auditor role",
+                "Source Manager role"
+            ],
             "x-enum-varnames": [
                 "Admin",
                 "Importer",
@@ -3786,6 +3889,9 @@
             "properties": {
                 "downloading": {
                     "type": "integer"
+                },
+                "healthy": {
+                    "type": "boolean"
                 },
                 "waiting": {
                     "type": "integer"
@@ -3956,6 +4062,9 @@
         "web.feed": {
             "type": "object",
             "properties": {
+                "healthy": {
+                    "type": "boolean"
+                },
                 "id": {
                     "type": "integer"
                 },
@@ -4105,6 +4214,9 @@
                     "items": {
                         "type": "string"
                     }
+                },
+                "healthy": {
+                    "type": "boolean"
                 },
                 "id": {
                     "type": "integer"

--- a/internal/web/events.go
+++ b/internal/web/events.go
@@ -120,7 +120,7 @@ func (c *Controller) overviewEvents(ctx *gin.Context) {
 				return fmt.Errorf("cannot fetch results: %w", err)
 			}
 			defer rows.Close()
-			if results, err = scanRows(rows, fields, builder.Aliases); err != nil {
+			if results, err = scanRows(rows, fields, builder.Aliases, builder.IgnoreFields); err != nil {
 				return fmt.Errorf("loading data failed: %w", err)
 			}
 			return nil

--- a/internal/web/sources.go
+++ b/internal/web/sources.go
@@ -620,7 +620,7 @@ type feedResult struct {
 //	@Summary		Returns feeds.
 //	@Description	Returns all feed configurations and metadata.
 //	@Param			id		path	int		true	"Source ID"
-//	@Param			health		path	int		true	"Source ID"
+//	@Param			health	path	int		true	"Source ID"
 //	@Param			stats	query	bool	false	"Enable statistic"
 //	@Param			health	query	bool	false	"Enable health indicator"
 //	@Produce		json


### PR DESCRIPTION
This avoids breaking changes by ignoring the `txt` field request, when search results are disabled. We may forbid this in the future to simplify the code.

Disabling search results also improves performance.