### PR TITLE
Improve style of CVSS label

### DIFF
--- a/client/src/lib/Advisories/CSAFWebview/Collapsible.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/Collapsible.svelte
@@ -22,6 +22,7 @@
     onClose?: () => any;
     children: Snippet;
     headerSlot?: Snippet;
+    headerRightSlot?: Snippet;
   }
   let {
     header,
@@ -37,7 +38,8 @@
       //default: Do nothing
     },
     children,
-    headerSlot = undefined
+    headerSlot = undefined,
+    headerRightSlot = undefined
   }: Props = $props();
   const uuid = crypto.randomUUID();
 
@@ -109,6 +111,9 @@
           <span class={getClass(level)}>{header}</span>
         {/if}
       </div>
+      <span class="ms-2">
+        {@render headerRightSlot?.()}
+      </span>
     </div>
     {#if visibility === "block"}
       <div id={uuid} class={`ml-2 pl-2 ${showBorder ? "border-l-2 border-l-gray-200" : ""}`}>

--- a/client/src/lib/Advisories/CSAFWebview/KeyValue.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/KeyValue.svelte
@@ -10,6 +10,7 @@
 
 <script lang="ts">
   import { Table, TableBody, TableBodyCell, TableBodyRow } from "flowbite-svelte";
+  import CVSS from "./general/CVSS.svelte";
 
   interface Props {
     keys: Array<string>;
@@ -17,7 +18,7 @@
   }
   let { keys, values }: Props = $props();
 
-  const cellStyle = "px-6 py-0";
+  const cellStyle = "px-6 py-1";
 </script>
 
 <div class="ml-2 w-fit">
@@ -33,6 +34,17 @@
                   {index}
                 </div>
               </div>
+            </TableBodyCell>
+          </TableBodyRow>
+        {:else if key === "baseScore" || key === "baseSeverity"}
+          <TableBodyRow color="default">
+            <TableBodyCell class={cellStyle}>{key}</TableBodyCell>
+            <TableBodyCell class={cellStyle}>
+              {#if key === "baseScore"}
+                <CVSS baseScore={values[index]}></CVSS>
+              {:else}
+                <CVSS baseSeverity={values[index]}></CVSS>
+              {/if}
             </TableBodyCell>
           </TableBodyRow>
         {:else}

--- a/client/src/lib/Advisories/CSAFWebview/general/CVSS.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/general/CVSS.svelte
@@ -21,7 +21,9 @@
 
 <div class={"score " + getSeverityClass(baseSeverity)}>
   <span class="baseScore">{baseScore}</span>
-  <span class="baseSeverity">({baseSeverity})</span>
+  {#if baseSeverity}
+    <span class="baseSeverity">({baseSeverity})</span>
+  {/if}
 </div>
 
 <style>
@@ -35,39 +37,36 @@
 
   .score.none {
     background: #53aa33;
-    border: 2px solid #53aa33;
   }
 
   .score.low {
     background: #ffcb0d;
-    border: 2px solid #ffcb0d;
   }
 
   .score.medium {
     background: #f9a009;
-    border: 2px solid #f9a009;
   }
 
   .score.high {
     background: #df3d03;
-    border: 2px solid #df3d03;
   }
 
   .score.critical {
     background: #cc0500;
-    border: 2px solid #cc0500;
   }
 
   .score {
     display: flex;
     flex-wrap: nowrap;
     gap: 2pt;
+    justify-content: center;
     margin: 0 15px;
-    border: 2px solid #666666;
     background: #dddddd;
+    color: black;
     font-size: small;
     font-weight: bolder;
     padding: 0.25em;
     height: fit-content;
+    min-width: 28pt;
   }
 </style>

--- a/client/src/lib/Advisories/CSAFWebview/general/CVSS.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/general/CVSS.svelte
@@ -8,7 +8,7 @@
  Software-Engineering: 2023 Intevation GmbH <https://intevation.de>
 -->
 <script lang="ts">
-  import { getCVSSTextualRating } from "$lib/Statistics/statistics";
+  import type { CVSSTextualRating } from "$lib/Statistics/statistics";
 
   interface Props {
     baseScore: string;
@@ -16,11 +16,25 @@
   }
   let { baseScore, baseSeverity }: Props = $props();
 
+  const getCVSSTextualRating = (CVSS: number): CVSSTextualRating => {
+    if (CVSS === 0) {
+      return "None";
+    } else if (CVSS <= 3.9) {
+      return "Low";
+    } else if (CVSS <= 6.9) {
+      return "Medium";
+    } else if (CVSS <= 8.9) {
+      return "High";
+    } else {
+      return "Critical";
+    }
+  };
+
   const getSeverityClass = (severity: string, score: string) => {
     if (severity) {
       return severity.toLowerCase();
     } else if (score) {
-      return getCVSSTextualRating(Number(score));
+      return getCVSSTextualRating(Number(score)).toLowerCase();
     }
   };
 </script>

--- a/client/src/lib/Advisories/CSAFWebview/general/CVSS.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/general/CVSS.svelte
@@ -58,37 +58,16 @@
     border: 2px solid #cc0500;
   }
 
-  .score span {
-    font-weight: bold;
-    width: 100%;
-  }
-
   .score {
-    top: -36px;
-    right: 0;
-    padding: 0 0.4em;
+    display: flex;
+    flex-wrap: nowrap;
+    gap: 2pt;
     margin: 0 15px;
     border: 2px solid #666666;
     background: #dddddd;
-    font-size: 11px;
-    border-radius: 10px;
-    width: 100px;
-    height: auto;
-    line-height: 150%;
-    text-align: center;
-  }
-
-  .baseScore {
-    display: block;
-    font-size: 32px;
-    line-height: 32px;
-    font-weight: normal;
-    margin-top: 4px;
-  }
-  .baseSeverity {
-    font-size: 16px;
-    font-weight: normal;
-    margin-bottom: 5px;
-    display: block;
+    font-size: small;
+    font-weight: bolder;
+    padding: 0.25em;
+    height: fit-content;
   }
 </style>

--- a/client/src/lib/Advisories/CSAFWebview/general/CVSS.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/general/CVSS.svelte
@@ -31,10 +31,18 @@
   };
 
   const getSeverityClass = (severity: string | undefined, score: string | undefined) => {
-    if (severity) {
-      return severity.toLowerCase();
-    } else if (score) {
-      return getCVSSTextualRating(Number(score)).toLowerCase();
+    if (severity && score) {
+      if (severity.toLowerCase() !== getCVSSTextualRating(Number(score)).toLowerCase()) {
+        return "";
+      } else {
+        return severity.toLowerCase();
+      }
+    } else {
+      if (severity) {
+        return severity.toLowerCase();
+      } else if (score !== undefined) {
+        return getCVSSTextualRating(Number(score)).toLowerCase();
+      }
     }
   };
 </script>
@@ -57,6 +65,7 @@
     color: #ffffff;
   }
 
+  .score,
   .score.low,
   .score.medium {
     color: #222;
@@ -88,7 +97,6 @@
     gap: 2pt;
     justify-content: center;
     background: #dddddd;
-    color: black;
     font-size: small;
     font-weight: bolder;
     padding: 0.25em;

--- a/client/src/lib/Advisories/CSAFWebview/general/CVSS.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/general/CVSS.svelte
@@ -50,11 +50,14 @@
 
 <style>
   .score.none,
-  .score.low,
-  .score.medium,
   .score.high,
   .score.critical {
     color: #ffffff;
+  }
+
+  .score.low,
+  .score.medium {
+    color: #222;
   }
 
   .score.none {

--- a/client/src/lib/Advisories/CSAFWebview/general/CVSS.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/general/CVSS.svelte
@@ -11,7 +11,7 @@
   import type { CVSSTextualRating } from "$lib/Statistics/statistics";
 
   interface Props {
-    baseScore: string;
+    baseScore?: string;
     baseSeverity?: string;
   }
   let { baseScore, baseSeverity }: Props = $props();
@@ -42,7 +42,9 @@
 {#if baseScore !== null && baseScore !== undefined}
   <div class={"score " + getSeverityClass(baseSeverity, baseScore)}>
     <span class="baseScore">{baseScore}</span>
-    {#if baseSeverity}
+    {#if baseSeverity && !baseScore}
+      <span class="baseSeverity">{baseSeverity}</span>
+    {:else if baseSeverity}
       <span class="baseSeverity">({baseSeverity})</span>
     {/if}
   </div>

--- a/client/src/lib/Advisories/CSAFWebview/general/CVSS.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/general/CVSS.svelte
@@ -67,6 +67,7 @@
     font-weight: bolder;
     padding: 0.25em;
     height: fit-content;
-    min-width: 28pt;
+    min-width: fit-content;
+    width: 50pt;
   }
 </style>

--- a/client/src/lib/Advisories/CSAFWebview/general/CVSS.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/general/CVSS.svelte
@@ -102,6 +102,6 @@
     padding: 0.25em;
     height: fit-content;
     min-width: fit-content;
-    width: 50pt;
+    width: 36pt;
   }
 </style>

--- a/client/src/lib/Advisories/CSAFWebview/general/CVSS.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/general/CVSS.svelte
@@ -30,7 +30,7 @@
     }
   };
 
-  const getSeverityClass = (severity: string | undefined, score: string | undefined) => {
+  const getClass = (severity: string | undefined, score: string | undefined) => {
     if (severity && score) {
       if (severity.toLowerCase() !== getCVSSTextualRating(Number(score)).toLowerCase()) {
         return "";
@@ -48,7 +48,7 @@
 </script>
 
 {#if baseScore !== null && baseScore !== undefined}
-  <div class={"score " + getSeverityClass(baseSeverity, baseScore)}>
+  <div class={"score " + getClass(baseSeverity, baseScore)}>
     <span class="baseScore">{baseScore}</span>
     {#if baseSeverity && !baseScore}
       <span class="baseSeverity">{baseSeverity}</span>

--- a/client/src/lib/Advisories/CSAFWebview/general/CVSS.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/general/CVSS.svelte
@@ -47,10 +47,10 @@
   };
 </script>
 
-{#if baseScore !== null && baseScore !== undefined}
+{#if baseScore !== null || baseSeverity !== undefined}
   <div class={"score " + getClass(baseSeverity, baseScore)}>
     <span class="baseScore">{baseScore}</span>
-    {#if baseSeverity && !baseScore}
+    {#if (baseSeverity && baseScore === null) || baseScore === undefined}
       <span class="baseSeverity">{baseSeverity}</span>
     {:else if baseSeverity}
       <span class="baseSeverity">({baseSeverity})</span>

--- a/client/src/lib/Advisories/CSAFWebview/general/CVSS.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/general/CVSS.svelte
@@ -8,18 +8,24 @@
  Software-Engineering: 2023 Intevation GmbH <https://intevation.de>
 -->
 <script lang="ts">
+  import { getCVSSTextualRating } from "$lib/Statistics/statistics";
+
   interface Props {
     baseScore: string;
     baseSeverity: string;
   }
   let { baseScore, baseSeverity }: Props = $props();
 
-  const getSeverityClass = (severity: string) => {
-    return severity.toLowerCase();
+  const getSeverityClass = (severity: string, score: string) => {
+    if (severity) {
+      return severity.toLowerCase();
+    } else if (score) {
+      return getCVSSTextualRating(Number(score));
+    }
   };
 </script>
 
-<div class={"score " + getSeverityClass(baseSeverity)}>
+<div class={"score " + getSeverityClass(baseSeverity, baseScore)}>
   <span class="baseScore">{baseScore}</span>
   {#if baseSeverity}
     <span class="baseSeverity">({baseSeverity})</span>

--- a/client/src/lib/Advisories/CSAFWebview/general/CVSS.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/general/CVSS.svelte
@@ -12,7 +12,7 @@
 
   interface Props {
     baseScore: string;
-    baseSeverity: string;
+    baseSeverity?: string;
   }
   let { baseScore, baseSeverity }: Props = $props();
 
@@ -30,7 +30,7 @@
     }
   };
 
-  const getSeverityClass = (severity: string, score: string) => {
+  const getSeverityClass = (severity: string | undefined, score: string | undefined) => {
     if (severity) {
       return severity.toLowerCase();
     } else if (score) {
@@ -39,12 +39,14 @@
   };
 </script>
 
-<div class={"score " + getSeverityClass(baseSeverity, baseScore)}>
-  <span class="baseScore">{baseScore}</span>
-  {#if baseSeverity}
-    <span class="baseSeverity">({baseSeverity})</span>
-  {/if}
-</div>
+{#if baseScore !== null && baseScore !== undefined}
+  <div class={"score " + getSeverityClass(baseSeverity, baseScore)}>
+    <span class="baseScore">{baseScore}</span>
+    {#if baseSeverity}
+      <span class="baseSeverity">({baseSeverity})</span>
+    {/if}
+  </div>
+{/if}
 
 <style>
   .score.none,
@@ -80,7 +82,6 @@
     flex-wrap: nowrap;
     gap: 2pt;
     justify-content: center;
-    margin: 0 15px;
     background: #dddddd;
     color: black;
     font-size: small;

--- a/client/src/lib/Advisories/CSAFWebview/general/General.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/general/General.svelte
@@ -45,7 +45,7 @@
         {/if}
       </div>
       {#if appStore.state.webview.doc?.highestScore}
-        <Cvss {baseScore} {baseSeverity}></Cvss>
+        <Cvss {baseScore} baseSeverity={baseSeverity ?? ""}></Cvss>
       {/if}
     </div>
   </div>

--- a/client/src/lib/Advisories/CSAFWebview/general/General.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/general/General.svelte
@@ -39,7 +39,7 @@
   <div class="mb-3">
     <div class="flex flex-row">
       <div>
-        <span class="text-xl">{title} </span>
+        <span class="text-xl text-balance">{title} </span>
         {#if appStore.state.webview.doc?.status !== Status.final}
           <span class="ml-3 text-lg text-gray-400">{status}</span>
         {/if}

--- a/client/src/lib/Advisories/CSAFWebview/general/General.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/general/General.svelte
@@ -37,7 +37,7 @@
 
 <div class="w-full">
   <div class="mb-3">
-    <div class="flex flex-row">
+    <div class="flex flex-row gap-2">
       <div>
         <span class="text-xl text-balance">{title} </span>
         {#if appStore.state.webview.doc?.status !== Status.final}

--- a/client/src/lib/Advisories/CSAFWebview/general/General.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/general/General.svelte
@@ -39,7 +39,7 @@
   <div class="mb-3">
     <div class="flex flex-row gap-2">
       <div>
-        <span class="text-xl text-balance">{title} </span>
+        <span class="-mt-1 inline-block text-xl text-balance">{title} </span>
         {#if appStore.state.webview.doc?.status !== Status.final}
           <span class="ml-3 text-lg text-gray-400">{status}</span>
         {/if}

--- a/client/src/lib/Advisories/CSAFWebview/vulnerabilities/vulnerability/Vulnerability.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/vulnerabilities/vulnerability/Vulnerability.svelte
@@ -52,13 +52,13 @@
   let currentCVE = $derived(vulnerability.cve);
   let highestScore: any = $derived.by(() => {
     if (vulnerability.scores) {
-      const cvss3Scores = vulnerability.scores.filter((s) => s.cvss_v3);
+      const cvss3Scores = vulnerability.scores.filter((s) => s.cvss_v3).map((s) => s.cvss_v3);
       if (cvss3Scores?.length > 0) {
-        return cvss3Scores.sort(compareScores)[0].cvss_v3;
+        return cvss3Scores.sort(compareScores)[0];
       }
-      const cvss2Scores = vulnerability.scores.filter((s) => s.cvss_v2);
+      const cvss2Scores = vulnerability.scores.filter((s) => s.cvss_v2).map((s) => s.cvss_v2);
       if (cvss2Scores?.length > 0) {
-        return cvss2Scores.sort(compareScores)[0].cvss_v2;
+        return cvss2Scores.sort(compareScores)[0];
       }
     }
   });

--- a/client/src/lib/Advisories/CSAFWebview/vulnerabilities/vulnerability/Vulnerability.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/vulnerabilities/vulnerability/Vulnerability.svelte
@@ -24,6 +24,8 @@
   import Threats from "./threats/Threats.svelte";
   import type { Vulnerability } from "$lib/pmdTypes";
   import { cveCutoff } from "../../efficiencyCutoffs";
+  import CVSS from "$lib/Advisories/CSAFWebview/general/CVSS.svelte";
+  import { compareScores } from "$lib/Advisories/CSAFWebview/vulnerabilities/vulnerability/scores/cvss";
 
   interface Props {
     basePath: string;
@@ -48,6 +50,18 @@
   let vulnerabilities = $derived(appStore.state.webview.doc?.vulnerabilities);
   let selectedCVE = $derived(appStore.state.webview.ui.selectedCVE);
   let currentCVE = $derived(vulnerability.cve);
+  let highestScore: any = $derived.by(() => {
+    if (vulnerability.scores) {
+      const cvss3Scores = vulnerability.scores.filter((s) => s.cvss_v3);
+      if (cvss3Scores?.length > 0) {
+        return cvss3Scores.sort(compareScores)[0].cvss_v3;
+      }
+      const cvss2Scores = vulnerability.scores.filter((s) => s.cvss_v2);
+      if (cvss2Scores?.length > 0) {
+        return cvss2Scores.sort(compareScores)[0].cvss_v2;
+      }
+    }
+  });
 
   let open = $derived.by(() => {
     if (vulnerabilities && vulnerabilities.length <= cveCutoff) {
@@ -71,7 +85,7 @@
   });
 </script>
 
-<div class={blink ? "blink" : ""}>
+<div class={blink ? "blink mb-1" : "mb-1"}>
   <Collapsible
     {header}
     level={3}
@@ -80,6 +94,9 @@
       appStore.resetSelectedCVE();
     }}
   >
+    {#snippet headerRightSlot()}
+      <CVSS baseSeverity={highestScore?.baseSeverity} baseScore={highestScore?.baseScore}></CVSS>
+    {/snippet}
     <div>
       <GeneralSection {vulnerability} />
       {#if vulnerability.Acknowledgments}

--- a/client/src/lib/Advisories/CSAFWebview/vulnerabilities/vulnerability/scores/CVSSV2.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/vulnerabilities/vulnerability/scores/CVSSV2.svelte
@@ -97,6 +97,6 @@
   }
 </script>
 
-<Collapsible header="CVSS V2" level={5}>
+<Collapsible open header="CVSS V2" level={5}>
   <KeyValue {keys} {values} />
 </Collapsible>

--- a/client/src/lib/Advisories/CSAFWebview/vulnerabilities/vulnerability/scores/CVSSV3.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/vulnerabilities/vulnerability/scores/CVSSV3.svelte
@@ -141,6 +141,6 @@
   }
 </script>
 
-<Collapsible header="CVSS V{score.cvss_v3.version}" level={5}>
+<Collapsible open header="CVSS V{score.cvss_v3.version}" level={5}>
   <KeyValue {keys} {values} />
 </Collapsible>

--- a/client/src/lib/Advisories/CSAFWebview/vulnerabilities/vulnerability/scores/Scores.svelte
+++ b/client/src/lib/Advisories/CSAFWebview/vulnerabilities/vulnerability/scores/Scores.svelte
@@ -22,10 +22,10 @@
   let { basePath = "", vulnerability }: Props = $props();
 </script>
 
-<Collapsible header="Scores" level={4}>
+<Collapsible open header="Scores" level={4}>
   {#if vulnerability.scores}
     {#each vulnerability.scores as score, index}
-      <Collapsible header="Score {index + 1}" level={4}>
+      <Collapsible open header="Score {index + 1}" level={4}>
         {#if score.cvss_v2}
           <CVSSV2 {score} />
         {/if}

--- a/client/src/lib/Advisories/CSAFWebview/vulnerabilities/vulnerability/scores/cvss.ts
+++ b/client/src/lib/Advisories/CSAFWebview/vulnerabilities/vulnerability/scores/cvss.ts
@@ -35,21 +35,21 @@ const compareScores = (a: any, b: any): number => {
       return 1;
     }
     return 0;
-  } else if (a.baseScore !== undefined && b.baseScore === undefined) {
+  } else if (a.baseScore !== undefined && b.baseScore === undefined && b.baseSeverity) {
     const range = getRangeOfCVSSSeverity(b.baseSeverity);
     if (a.baseScore < range[0]) {
       return -1;
     } else if (a.baseScore > range[1]) {
       return 1;
     }
-  } else if (a.baseScore === undefined && b.baseScore !== undefined) {
+  } else if (a.baseScore === undefined && b.baseScore !== undefined && a.baseSeverity) {
     const range = getRangeOfCVSSSeverity(a.baseSeverity);
     if (range[1] < b.baseScore) {
       return -1;
     } else if (range[0] > b.baseScore) {
       return 1;
     }
-  } else {
+  } else if (a.baseSeverity && b.baseSeverity) {
     const rangeA = getRangeOfCVSSSeverity(a.baseSeverity);
     const rangeB = getRangeOfCVSSSeverity(b.baseSeverity);
     if (rangeA[0] < rangeB[0]) {

--- a/client/src/lib/Advisories/CSAFWebview/vulnerabilities/vulnerability/scores/cvss.ts
+++ b/client/src/lib/Advisories/CSAFWebview/vulnerabilities/vulnerability/scores/cvss.ts
@@ -1,0 +1,64 @@
+// This file is Free Software under the Apache-2.0 License
+// without warranty, see README.md and LICENSES/Apache-2.0.txt for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: 2025 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+//  Software-Engineering: 2025 Intevation GmbH <https://intevation.de>
+
+const getRangeOfCVSSSeverity = (severity: string): number[] => {
+  const sev = severity.toLowerCase();
+  if (sev === "none") {
+    return [0, 0];
+  } else if (sev === "low") {
+    return [0.1, 3.9];
+  } else if (sev === "medium") {
+    return [4.0, 6.9];
+  } else if (sev === "high") {
+    return [7.0, 8.9];
+  } else {
+    return [9.0, 10];
+  }
+};
+
+/**
+ * This method is intended to be used by the method Array.sort().
+ * @param a CVSS2/CVSS3 score object
+ * @param b CVSS2/CVSS3 score object
+ * @returns {number}
+ */
+const compareScores = (a: any, b: any): number => {
+  if (a.baseScore !== undefined && b.baseScore !== undefined) {
+    if (a < b) {
+      return -1;
+    } else if (a > b) {
+      return 1;
+    }
+    return 0;
+  } else if (a.baseScore !== undefined && b.baseScore === undefined) {
+    const range = getRangeOfCVSSSeverity(b.baseSeverity);
+    if (a.baseScore < range[0]) {
+      return -1;
+    } else if (a.baseScore > range[1]) {
+      return 1;
+    }
+  } else if (a.baseScore === undefined && b.baseScore !== undefined) {
+    const range = getRangeOfCVSSSeverity(a.baseSeverity);
+    if (range[1] < b.baseScore) {
+      return -1;
+    } else if (range[0] > b.baseScore) {
+      return 1;
+    }
+  } else {
+    const rangeA = getRangeOfCVSSSeverity(a.baseSeverity);
+    const rangeB = getRangeOfCVSSSeverity(b.baseSeverity);
+    if (rangeA[0] < rangeB[0]) {
+      return -1;
+    } else if (rangeA[0] > rangeB[0]) {
+      return 1;
+    }
+  }
+  return 0;
+};
+
+export { compareScores };

--- a/client/src/lib/Dashboard/AdvisoryQuery.svelte
+++ b/client/src/lib/Dashboard/AdvisoryQuery.svelte
@@ -22,6 +22,7 @@
   import { getRelativeTime } from "$lib/time";
   import SsvcBadge from "$lib/Advisories/SSVC/SSVCBadge.svelte";
   import ShowMoreButton from "./ShowMoreButton.svelte";
+  import CVSS from "$lib/Advisories/CSAFWebview/general/CVSS.svelte";
 
   interface Props {
     storedQuery: any;
@@ -103,9 +104,7 @@
               {#snippet topLeftSlot()}
                 <div>
                   {#if doc.critical}
-                    <span class:text-red-500={Number(doc.critical) > 5.0}>
-                      {doc.critical}
-                    </span>
+                    <CVSS baseScore={doc.critical}></CVSS>
                   {/if}
                 </div>
               {/snippet}

--- a/client/src/lib/Statistics/statistics.ts
+++ b/client/src/lib/Statistics/statistics.ts
@@ -14,7 +14,7 @@ import type { Result } from "$lib/types";
 type StatisticEntry = [Date, number | null];
 type Statistic = StatisticEntry[];
 
-type CVSSTextualRating = "None" | "Low" | "Medium" | "High";
+type CVSSTextualRating = "None" | "Low" | "Medium" | "High" | "Critical";
 type CritStatisticEntry = [CVSSTextualRating | number];
 type CritStatistic = [Date, CritStatisticEntry[]];
 

--- a/client/src/lib/Table/Table.svelte
+++ b/client/src/lib/Table/Table.svelte
@@ -41,6 +41,7 @@
   import { areArraysEqual } from "$lib/utils";
   import DeleteModal from "./DeleteModal.svelte";
   import { updateMultipleStates } from "$lib/Advisories/advisory";
+  import CVSS from "$lib/Advisories/CSAFWebview/general/CVSS.svelte";
 
   let openRow: number | null = $state(null);
   let abortController: AbortController;
@@ -706,14 +707,8 @@
                         aria-label="View advisory details"
                       >
                       </a>
-                      <div class="m-2 table w-full text-wrap">
-                        <span
-                          class:text-red-500={Number(item[column]) > 5.0}
-                          class:dark:text-red-300={Number(item[column]) > 5.0}
-                          >{item[column] == null ? "" : item[column]}</span
-                        >
-                      </div></TableBodyCell
-                    >
+                      <CVSS baseScore={item[column]}></CVSS>
+                    </TableBodyCell>
                   {:else if column === "ssvc"}
                     <TableBodyCell class={tdClass}
                       ><a
@@ -869,14 +864,8 @@
                         href={getAdvisoryAnchorLink(item)}
                       >
                       </a>
-                      <div class="m-2 table w-full text-wrap">
-                        <span
-                          class:text-red-500={Number(item[column]) > 5.0}
-                          class:dark:text-red-300={Number(item[column]) > 5.0}
-                          >{item[column] == null ? "" : item[column]}</span
-                        >
-                      </div></TableBodyCell
-                    >
+                      <CVSS baseScore={item[column]}></CVSS>
+                    </TableBodyCell>
                   {:else if column === "tracking_id"}
                     <TableBodyCell class={tdClass}
                       ><a


### PR DESCRIPTION
Prevent that it's getting resized and make it look more like the TLP label.

Before, the height of the CVSS label did change on different screen sizes when the title takes more or less space in the vertical direction:
<img height="200" alt="before" src="https://github.com/user-attachments/assets/46e5bdc4-5c4f-4dcb-bf74-9107eec67102" />
<img height="200" alt="before-2" src="https://github.com/user-attachments/assets/46af14d2-3e08-4500-9bcb-68f22d58e420" />

Now, the height stays the same and it has no border radius so its shape looks like the one of the TLP label:
<img height="200" alt="after-dark-1" src="https://github.com/user-attachments/assets/8323c83d-5939-428d-8999-521902c36da5" />
<img  height="200" alt="after-light-1" src="https://github.com/user-attachments/assets/e3544928-c73c-4e56-853a-29c277679dfc" />
<img height="200" alt="after-light-2" src="https://github.com/user-attachments/assets/6ee34728-00d4-4c62-b1f9-50a41d729489" />


Solves #801.