### PR TITLE
Fix: Application of classes for table body cells

### DIFF
--- a/client/src/lib/Sources/FeedView.svelte
+++ b/client/src/lib/Sources/FeedView.svelte
@@ -212,7 +212,7 @@
             </TableBodyCell>
             <TableBodyCell
               onclick={async () => await clickFeed(feed)}
-              class={`$class={tdClass} break-all whitespace-normal`}
+              class={`${tdClass} break-all whitespace-normal`}
             >
               {#if edit && feed.enable}
                 <a

--- a/client/src/lib/Sources/Overview.svelte
+++ b/client/src/lib/Sources/Overview.svelte
@@ -139,7 +139,7 @@
             <TableBodyCell class="w-fit max-w-10">
               <i class="bx bx-git-repo-forked"></i>
             </TableBodyCell>
-            <TableBodyCell class={`$class={tdClass} break-words hyphens-auto`}>
+            <TableBodyCell class={`${tdClass} break-words hyphens-auto`}>
               <div class="whitespace-break-spaces">
                 <span>{source.name}</span>
                 {#if source.attention}
@@ -148,7 +148,7 @@
               </div>
             </TableBodyCell>
             {#if source.id !== 0}
-              <TableBodyCell class={`$class={tdClass} break-all whitespace-normal`}
+              <TableBodyCell class={`${tdClass} break-all whitespace-normal`}
                 >{source.url}</TableBodyCell
               >
               <TableBodyCell class={tdClass}
@@ -162,12 +162,12 @@
                 ></i></TableBodyCell
               >
             {:else}
-              <TableBodyCell></TableBodyCell>
-              <TableBodyCell></TableBodyCell>
-              <TableBodyCell></TableBodyCell>
-              <TableBodyCell></TableBodyCell>
+              <TableBodyCell class={tdClass}></TableBodyCell>
+              <TableBodyCell class={tdClass}></TableBodyCell>
+              <TableBodyCell class={tdClass}></TableBodyCell>
+              <TableBodyCell class={tdClass}></TableBodyCell>
             {/if}
-            <TableBodyCell>
+            <TableBodyCell class={tdClass}>
               {#if source.id !== undefined}
                 {@const yesterday = Date.now() - DAY_MS}
                 <SourceBasicStats

--- a/client/src/lib/Statistics/StatsTable.svelte
+++ b/client/src/lib/Statistics/StatsTable.svelte
@@ -46,7 +46,7 @@
             {#each Object.keys(stats) as key}
               {@const count = stats[key]?.[index][1]}
               <TableBodyCell
-                class={`$class={tdClass} ${typeof count === "number" && count !== 0 ? "" : "!text-gray-400"}`}
+                class={`${tdClass} ${typeof count === "number" && count !== 0 ? "" : "!text-gray-400"}`}
                 >{count ?? 0}</TableBodyCell
               >
             {/each}

--- a/client/src/lib/Table/CustomTable.svelte
+++ b/client/src/lib/Table/CustomTable.svelte
@@ -60,7 +60,7 @@
       class={stickyHeaders ? "sticky top-[0] bg-white dark:bg-gray-800" : "dark:bg-gray-800"}
     >
       {#each headers as header}
-        <TableHeadCell class={header.class ?? ""} padding={tablePadding} onclick={() => {}}>
+        <TableHeadCell class={header.class ?? tablePadding} onclick={() => {}}>
           <span>{header.label}</span>
           <i
             class:bx={true}


### PR DESCRIPTION
This PR fixes classes for table cells. Partly layout issues are remainder of flowbite-svelte migration and partly probably because of a replace-all-action. Then this PR applies classes where they were missing until now for more consistency.