### PR TITLE
fix: Add padding to query table

### DIFF
--- a/client/src/lib/Queries/QueryTable.svelte
+++ b/client/src/lib/Queries/QueryTable.svelte
@@ -170,7 +170,7 @@
     <span class="text-2xl">{title}</span>
   </div>
   <hr class="mb-6" />
-  <div id={tableContainerID} class="mb-2 max-h-[66vh] overflow-auto">
+  <div id={tableContainerID} class="mb-2 max-h-[66vh] overflow-auto pe-2">
     <Table hoverable={true} border={false}>
       <TableHead class="dark:bg-gray-800">
         <TableHeadCell class={tablePadding}></TableHeadCell>


### PR DESCRIPTION
Before when hovering over the scrollbar in Firefox the bar overlapped part of the delete button.
<img width="872" height="609" alt="Screenshot from 2026-01-26 11-06-18" src="https://github.com/user-attachments/assets/b2105d80-e86d-49e5-9643-23fddc53982e" />
