### PR TITLE
Prevent duplicate request to backend

### DIFF
--- a/client/src/lib/Search/Queries.svelte
+++ b/client/src/lib/Search/Queries.svelte
@@ -80,7 +80,7 @@
     if (response.ok) {
       queries = response.content.filter((q: Query) => !q.dashboard && !q.default_query);
       let defaultQueries = response.content.filter((q: Query) => q.default_query);
-      if (defaultQueries) {
+      if (defaultQueries?.length > 0) {
         defaultQuery = defaultQueries[0];
       }
     } else if (response.error) {


### PR DESCRIPTION
`$effect` runes that "listen" to `defaultQuery` run even if it only changes from `null` to `undefined`. Before this commit this led to a duplicate request.

This affects #1245 because if we save the URL in the browser history every time a request is sent (because parameters were changed) we would push the URL twice onto the browser history stack so users would need to go back twice to get to the result they wanted.