### PR TITLE
Prevent duplicate requests to load events/comments

### DIFF
--- a/client/src/lib/Advisories/Advisory.svelte
+++ b/client/src/lib/Advisories/Advisory.svelte
@@ -336,9 +336,6 @@
       await loadFourCVEs();
       await loadDocumentSSVC();
       await buildHistory();
-      if (appStore.isEditor() || appStore.isReviewer() || appStore.isAuditor()) {
-        await buildHistory();
-      }
       await loadAdvisoryState();
       loadRelatedDocuments();
       // Only set state to 'read' if editor opens the current version.


### PR DESCRIPTION
For most roles the method buildHistory was called twice. Also, the if-statement was not needed because the method itself checked already if the user could see comments/events.