### PR TITLE
Make SSVC badge look like label

### DIFF
--- a/client/src/lib/Advisories/SSVC/SSVCBadge.svelte
+++ b/client/src/lib/Advisories/SSVC/SSVCBadge.svelte
@@ -22,4 +22,4 @@
   let style = $derived(ssvc.color ? `color: white; background-color: ${ssvc.color};` : "");
 </script>
 
-<Badge class="h-6 w-fit" title={ssvc.vector} {style}>{ssvc.label}</Badge>
+<Badge class="h-fit w-fit rounded-none px-1 py-1" title={ssvc.vector} {style}>{ssvc.label}</Badge>


### PR DESCRIPTION
Buttons are rounded and labels beside the SSVC badge are not so the badge had to be changed to be consistent with other labels.

Also make the badge smaller.

Before:

<img width="492" height="444" alt="Screenshot from 2026-02-23 14-16-33" src="https://github.com/user-attachments/assets/9388e6fd-fd60-40bf-a5f6-b139bd3dd480" />

After:

<img width="492" height="444" alt="Screenshot from 2026-02-23 14-17-35" src="https://github.com/user-attachments/assets/8586a5db-df83-461f-bef5-7425fd7f4b15" />
