### PR TITLE
Configure Dependabot to update GH actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,7 @@ updates:
     schedule:
       interval: "weekly"
     labels: [ ]
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This way we don't have to put it on the release todo list.