### PR TITLE
Disable automatic Playwright tests

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -8,9 +8,7 @@
 
 name: Playwright Tests
 on:
-  push:
-  pull_request:
-    branches: [main]
+  workflow_dispatch:
 jobs:
   test:
     timeout-minutes: 60


### PR DESCRIPTION
The results were often false positive so we want to ensure that the tests deliver stable results before we enable automatic tests again.