### PR TITLE
Disable file input while documents are uploaded

### DIFF
--- a/client/src/lib/Upload.svelte
+++ b/client/src/lib/Upload.svelte
@@ -58,6 +58,7 @@
       <Label class="pb-2">{label}</Label>
       {#if showFileInput}
         <Fileupload
+          disabled={isUploading}
           wrapperClass="cursor-pointer disabled:cursor-not-allowed !p-0 dark:text-gray-400"
           class="file:bg-primary-700 hover:file:bg-primary-800 dark:file:bg-primary-600 dark:hover:file:bg-primary-700 text-white dark:text-white"
           value=""


### PR DESCRIPTION
This **might** solve #1317 because the setup test will probably have to wait until the upload is finished until it can call `setInputFiles` again. And if it waits then the upload button should be enabled the second time.

Since we are also disable the upload button while the files are uploaded it is consistent to disable the file input too.