### PR TITLE
Require Go 1.26 for backend

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@
 
 module github.com/ISDuBA/ISDuBA
 
-go 1.25.3
+go 1.26.0
 
 require (
 	github.com/BurntSushi/toml v1.6.0

--- a/pkg/database/query/parser.go
+++ b/pkg/database/query/parser.go
@@ -542,10 +542,8 @@ func (e *Expr) checkValueType(vt valueType) {
 }
 
 func (e *Expr) checkExprType(eTypes ...exprType) {
-	for _, et := range eTypes {
-		if e.exprType == et {
-			return
-		}
+	if slices.Contains(eTypes, e.exprType) {
+		return
 	}
 	panic(parseError(
 		fmt.Sprintf("expression type mismatch: %q %v", e.exprType, eTypes)))

--- a/pkg/web/sources.go
+++ b/pkg/web/sources.go
@@ -972,7 +972,7 @@ func (c *Controller) feedLogs(ctx *gin.Context, feedID *int64) {
 	}
 
 	if lvls := ctx.Query("levels"); lvls != "" {
-		for _, lvl := range strings.Fields(lvls) {
+		for lvl := range strings.FieldsSeq(lvls) {
 			logLevel, ok := parse(ctx, config.ParseFeedLogLevel, lvl)
 			if !ok {
 				return


### PR DESCRIPTION
and apply 'go fix' to simple cases.