### PR TITLE
Use same component for files as in source form

### DIFF
--- a/client/src/lib/Components/CFileinput.svelte
+++ b/client/src/lib/Components/CFileinput.svelte
@@ -12,6 +12,8 @@
   import { Button, Label } from "flowbite-svelte";
 
   interface Props {
+    accept?: string;
+    browseButtonColor?: "primary" | "light";
     containerClass?: string | undefined;
     clearable?: boolean;
     disabled?: boolean;
@@ -25,6 +27,8 @@
   }
 
   let {
+    accept = "",
+    browseButtonColor = "primary",
     containerClass = undefined,
     clearable = true,
     disabled = false,
@@ -48,8 +52,8 @@
     onclick={() => {
       document.getElementById(id)?.click();
     }}
-    class="rounded-none rounded-l-lg border border-r-0 dark:border-gray-700 dark:bg-gray-800"
-    color="primary"
+    class="cursor-pointer rounded-none rounded-l-lg border-r-0 disabled:cursor-not-allowed"
+    color={browseButtonColor}
     {disabled}>Browse...</Button
   >
   <Label
@@ -68,7 +72,7 @@
       <span>No file selected</span>
     {/if}
   </Label>
-  <input {multiple} onchange={onChange} {disabled} {id} type="file" />
+  <input {multiple} onchange={onChange} {accept} {disabled} {id} type="file" />
   {#if clearable}
     <Button
       onclick={() => {
@@ -77,8 +81,9 @@
         isFileReset = true;
         onChanged();
       }}
+      {disabled}
       title={titleClearButton}
-      class="w-fit rounded-none rounded-r-lg border-l-0 p-1 dark:border-gray-500 dark:bg-gray-600"
+      class="w-fit cursor-pointer rounded-none rounded-r-lg border-l-0 p-1 disabled:cursor-not-allowed dark:border-gray-500 dark:bg-gray-600"
       color="light"
     >
       <i class="bx bx-x"></i>

--- a/client/src/lib/Sources/SourceForm.svelte
+++ b/client/src/lib/Sources/SourceForm.svelte
@@ -252,6 +252,7 @@
       <CFileinput
         bind:files={privateCert}
         bind:isFileReset={privateCertReset}
+        browseButtonColor="light"
         oldFile={oldSource?.client_cert_private}
         onChanged={inputChange}
         id="private-cert"
@@ -261,6 +262,7 @@
       <CFileinput
         bind:files={publicCert}
         bind:isFileReset={publicCertReset}
+        browseButtonColor="light"
         oldFile={oldSource?.client_cert_public}
         onChanged={inputChange}
         id="public-cert"

--- a/client/src/lib/Upload.svelte
+++ b/client/src/lib/Upload.svelte
@@ -9,9 +9,9 @@
 -->
 
 <script lang="ts">
-  import { Button, Card, Fileupload, Label, Listgroup, ListgroupItem } from "flowbite-svelte";
+  import { Button, Card, Label, Listgroup, ListgroupItem } from "flowbite-svelte";
   import { type UploadInfo } from "$lib/Sources/source";
-  import { tick } from "svelte";
+  import CFileinput from "./Components/CFileinput.svelte";
 
   interface Props {
     cancel: () => any;
@@ -44,7 +44,6 @@
   let files: FileList | undefined = $state(undefined);
   let filesCache: FileList | undefined = $state(undefined);
   let isUploading = $state(false);
-  let showFileInput = $state(true);
   $effect(() => {
     if (files) {
       uploadInfo = [];
@@ -56,20 +55,16 @@
   <div class={`flex flex-col gap-4 ${files?.length && files.length > 1 ? "mb-4" : "mb-40"}`}>
     <div>
       <Label class="pb-2">{label}</Label>
-      {#if showFileInput}
-        <Fileupload
-          disabled={isUploading}
-          wrapperClass="cursor-pointer disabled:cursor-not-allowed !p-0 dark:text-gray-400"
-          class="file:bg-primary-700 hover:file:bg-primary-800 dark:file:bg-primary-600 dark:hover:file:bg-primary-700 text-white dark:text-white"
-          value=""
-          bind:files
-          multiple
-          accept=".json"
-          onchange={() => {
-            filesCache = undefined;
-          }}
-        />
-      {/if}
+      <CFileinput
+        accept=".json"
+        disabled={isUploading}
+        id="upload-files"
+        multiple
+        bind:files
+        onChanged={() => {
+          filesCache = undefined;
+        }}
+      />
     </div>
     <div class="flex items-center justify-end gap-2">
       {#if isUploading}
@@ -101,11 +96,6 @@
               });
             }
             files = undefined;
-            // This is a hack. The file input has to be re-added to the DOM. Otherwise it would not change
-            // the label "x files selected." to its initial value even if we set files to undefined.
-            showFileInput = false;
-            await tick();
-            showFileInput = true;
             isUploading = false;
           });
         }}


### PR DESCRIPTION
- more consistency
- removes workaround that may have negative side effects in playwright tests