### PR TITLE
Replace more <a> elements with buttons

### DIFF
--- a/client/src/lib/Errors/ErrorMessage.svelte
+++ b/client/src/lib/Errors/ErrorMessage.svelte
@@ -25,13 +25,13 @@
     <Alert color="red" class="gap-3 p-4 text-sm dark:bg-[#302834]" dismissable>
       <span class="text-lg"> {error.message}</span>
       {#if error.details}
-        <a href={"javascript:void(0);"} onclick={() => (showDetails = !showDetails)}>
+        <button class="cursor-pointer" onclick={() => (showDetails = !showDetails)}>
           {#if showDetails}
             <i class="bx bx-chevron-up text-2xl"></i>
           {:else}
             <i class="bx bx-chevron-down text-2xl"></i>
           {/if}
-        </a>
+        </button>
         {#if showDetails}
           <br />
           <span class="text-lg whitespace-pre-wrap">{error.details}</span>

--- a/client/src/lib/Sources/FeedView.svelte
+++ b/client/src/lib/Sources/FeedView.svelte
@@ -180,12 +180,12 @@
           {#if placeholderFeed}
             <TableBodyCell class={tdClass}>{feed.label}</TableBodyCell>
             <TableBodyCell onclick={async () => await clickFeed(feed)} class={tdClass}>
-              <a
-                href={"javascript:void(0);"}
+              <button
+                class="cursor-pointer"
                 onclick={async () => await clickFeed(feed)}
                 aria-label="View feed archive"
               >
-                <i class="bx bx-archive"> </i></a
+                <i class="bx bx-archive"> </i></button
               >
             </TableBodyCell>
           {:else}
@@ -215,10 +215,10 @@
               class={`${tdClass} break-all whitespace-normal`}
             >
               {#if edit && feed.enable}
-                <a
-                  href={"javascript:void(0);"}
+                <button
+                  class="cursor-pointer"
                   onclick={async () => await clickFeed(feed)}
-                  aria-label="View feed details">{feed.url}</a
+                  aria-label="View feed details">{feed.url}</button
                 >
               {:else}
                 <span class="text-amber-600">
@@ -250,12 +250,12 @@
               >
               {#if feed.enable}
                 <TableBodyCell onclick={async () => await clickFeed(feed)} class={tdClass}>
-                  <a
-                    href={"javascript:void(0);"}
+                  <button
+                    class="cursor-pointer"
                     onclick={async () => await clickFeed(feed)}
                     aria-label="View feed archive"
                   >
-                    <i class="bx bx-archive"> </i></a
+                    <i class="bx bx-archive"> </i></button
                   >
                 </TableBodyCell>
               {/if}


### PR DESCRIPTION
It's no good style to use "javascript:void(0);" for elements. The links don't let the user navigate to another page and they don't lead the user to another HTML element so it doesn't make sense to use the anchor element.