### PR TITLE
Temporary event search fix

### DIFF
--- a/pkg/database/query/sqlbuilder.go
+++ b/pkg/database/query/sqlbuilder.go
@@ -1,4 +1,4 @@
-//// This file is Free Software under the Apache-2.0 License
+// This file is Free Software under the Apache-2.0 License
 // without warranty, see README.md and LICENSES/Apache-2.0.txt for details.
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -88,13 +88,16 @@ func (sb *SQLBuilder) searchWhere(e *Expr, b *strings.Builder) {
 				"AND documents_texts.documents_id = documents.id)", sb.replacementIndex(LikeEscape(e.stringValue))+1)
 		case EventMode:
 			// TODO clarify how to handle event search
-			// Current implementation equals AdvisoryMode/DocumentMode to prevent error when searching for strings, but can't search e.g. in comments
+			// Current implementation equals AdvisoryMode/DocumentMode to prevent error when searching for strings, but can also search in comments
 			fmt.Fprintf(b, "EXISTS(SELECT 1 FROM documents_texts "+
 				"JOIN unique_texts ON unique_texts.id = documents_texts.txt_id "+
-				"WHERE txt ILIKE $%d "+
-				"AND documents_texts.documents_id = documents.id)", sb.replacementIndex(LikeEscape(e.stringValue))+1)
-
+				"WHERE txt ILIKE $%[1]d "+
+				"AND documents_texts.documents_id = documents.id) "+
+				"OR "+
+				"EXISTS(SELECT 1 FROM comments "+
+				"WHERE message ILIKE $%[1]d AND comments.documents_id = documents.id)", sb.replacementIndex(LikeEscape(e.stringValue))+1)
 		}
+
 		// Ignore alias for now to avoid breaking change
 		if e.alias == "" {
 			return


### PR DESCRIPTION
Solves https://github.com/ISDuBA/ISDuBA/issues/1360

When searching events for text now, this implementation returns every event related to an advisory where the text was found in the advisory or in comments. 

https://github.com/ISDuBA/ISDuBA/issues/1349 might solve this more gracefully, but for now this is usable and prevents an error.

