### PR TITLE
fix: Make text readable on hover again

### DIFF
--- a/client/src/lib/Advisories/WorkflowButton.svelte
+++ b/client/src/lib/Advisories/WorkflowButton.svelte
@@ -26,7 +26,7 @@
 </script>
 
 <button class={buttonClass} onclick={(event: any) => onClick(event)}>
-  <CBadge title={tooltip} class="flex w-fit gap-1" {color}>
+  <CBadge showHoverEffect={false} title={tooltip} class="flex w-fit gap-1" {color}>
     {@render icon()}
     <span>{label}</span>
   </CBadge>

--- a/client/src/lib/Components/CBadge.svelte
+++ b/client/src/lib/Components/CBadge.svelte
@@ -24,6 +24,7 @@
     large?: boolean;
     dismissable?: boolean;
     border?: boolean;
+    showHoverEffect?: boolean;
     rounded?: boolean;
     transition?: TransitionFunc;
     params?: object;
@@ -37,6 +38,7 @@
     large = false,
     dismissable = false,
     border = false,
+    showHoverEffect = true,
     rounded = false,
     transition = fade,
     params = {},
@@ -103,7 +105,7 @@
       baseClass,
       large ? "text-sm" : "text-xs",
       border ? `border ${borderedColors[color]}` : colors[color],
-      hoverColors[color],
+      showHoverEffect ? hoverColors[color] : "",
       rounded ? "rounded-full" : "rounded",
       `${restProps.class}`
     )


### PR DESCRIPTION
When the user hovers over a workflow button in **dark mode** the text is not easy readable:
<img width="541" height="69" alt="Screenshot from 2026-03-13 09-09-43" src="https://github.com/user-attachments/assets/09f1ed28-52b2-4bb0-abdc-48336c875ae6" />
