### PR TITLE
fix: SSVC calculator layout

### DIFF
--- a/client/src/lib/Advisories/SSVC/ComplexDecision.svelte
+++ b/client/src/lib/Advisories/SSVC/ComplexDecision.svelte
@@ -29,7 +29,7 @@
   });
 </script>
 
-<div class="complex-decision flex flex-row gap-x-5">
+<div class="complex-decision flex flex-wrap gap-x-5 gap-y-3">
   {#if children && decisionPoints}
     {#each children as child}
       {@const childOptions = getDecision(decisionPoints, child.label)?.options}


### PR DESCRIPTION
Not all options of a complex decision were visible right away.

Before (you had to scroll to see the last option):
<img width="486" height="231" alt="Screenshot from 2026-03-13 16-24-45" src="https://github.com/user-attachments/assets/153b7720-c0bb-4614-9768-d2ebefad0167" />

After:
<img width="486" height="300" alt="Screenshot from 2026-03-13 16-24-56" src="https://github.com/user-attachments/assets/e35088da-29c4-4f10-9d92-64c9cb1a5ccd" />
