### PR TITLE
Wait until initial search request is finished

### DIFF
--- a/client/tests/cve_compare_test.ts
+++ b/client/tests/cve_compare_test.ts
@@ -11,6 +11,7 @@ import { test } from "./fixtures";
 
 test("cve comparison is working", async ({ page }) => {
   await page.goto("/#/search");
+  await expect(page.getByText("advisories in total")).toBeVisible();
   await page.getByPlaceholder("Enter a search term").fill("avendor");
   await page.getByRole("button", { name: "Search", exact: true }).click();
 

--- a/client/tests/documentView_test.ts
+++ b/client/tests/documentView_test.ts
@@ -12,6 +12,7 @@ import { vectorStart } from "$lib/Advisories/SSVC/SSVCCalculator";
 
 test("Advisory view is working", async ({ page }) => {
   await page.goto("/#/search");
+  await expect(page.getByText("advisories in total")).toBeVisible();
   await page.getByPlaceholder("Enter a search term").fill("avendor");
   await page.getByRole("button", { name: "Search", exact: true }).click();
   await page.getByText("Avendor-advisory-0004").first().click({ force: true });
@@ -55,8 +56,8 @@ test("Advisory view is working", async ({ page }) => {
   await page.getByRole("button", { name: "Save" }).click();
   const newSsvcBadge = page.getByText("Attend").first();
   await expect(newSsvcBadge).toBeVisible();
-  const toText = page.getByText(`TO: ${vectorStart}${secondSSVC}`);
+  const toText = page.getByText(`TO: ${vectorStart}${secondSSVC}`).first();
   await expect(toText).toBeVisible();
-  const fromText = page.getByText(`FROM: ${autoCalculatedSSVC}`);
+  const fromText = page.getByText(`FROM: ${autoCalculatedSSVC}`).first();
   await expect(fromText).toBeVisible();
 });


### PR DESCRIPTION
This reduces the risk of race conditions.