### PR TITLE
fix: Default query was overwritten by global one

### DIFF
--- a/client/src/lib/Search/Overview.svelte
+++ b/client/src/lib/Search/Overview.svelte
@@ -32,6 +32,7 @@
   const INITIAL_LIMIT = 10;
   const INITIAL_ORDER = ["-critical"];
 
+  let queriesLoaded = $state(false);
   let loading = $state(false);
   let openRow: number | null = $state(null);
   let count = $state(0);
@@ -256,16 +257,10 @@
   };
 
   $effect(() => {
-    // If queryID is defined we expect the data for that query to be fetched but initially the queries are not
-    // loaded so we have to wait until they are. Then we can read the necessary information from selectedQuery
-    // and do the request.
-    const qID = untrack(() => queryID);
-    if (qID !== undefined && queries === null) return;
-
     // This rune is also called when a different was opened. In this case the parameters are reset to their defaults
     // and the count and the results saved in the store are not the expected ones.
     const hash = untrack(() => page.url.hash);
-    if ($qs !== undefined && hash.startsWith("#/search")) {
+    if (queriesLoaded && $qs !== undefined && hash.startsWith("#/search")) {
       fetchData();
     }
   });
@@ -369,6 +364,9 @@
 <div class="mb-8 flex flex-wrap justify-between gap-4">
   <Queries
     selectedType={type}
+    onLoadedQueries={() => {
+      queriesLoaded = true;
+    }}
     onQuerySelected={(id: number | undefined) => {
       const newParameters: SearchParameters = {
         currentPage: 1,

--- a/client/src/lib/Search/Queries.svelte
+++ b/client/src/lib/Search/Queries.svelte
@@ -27,11 +27,12 @@
   import type { Query, SEARCHTYPES } from "$lib/Queries/query";
 
   interface Props {
+    onLoadedQueries: () => void;
     onQuerySelected: (id: number | undefined) => void;
     selectedType: SEARCHTYPES;
   }
 
-  let { onQuerySelected, selectedType }: Props = $props();
+  let { onLoadedQueries, onQuerySelected, selectedType }: Props = $props();
 
   const uid = $props.id();
 
@@ -83,7 +84,7 @@
   };
 
   onMount(async () => {
-    fetchIgnored();
+    await fetchIgnored();
     queryState.queries = [];
     queryState.ignoredQueries = [];
     const response = await request("/api/queries", "GET");
@@ -92,6 +93,7 @@
     } else if (response.error) {
       errorMessage = getErrorDetails(`Could not load user defined queries.`, response);
     }
+    onLoadedQueries();
   });
 
   const selectQuery = (id: number | undefined) => {


### PR DESCRIPTION
It could happen that the table showed the results of the personal default query which was selected. But after few seconds they were replaced by the results of the global default query. Probably because the first request caused by the global query was slower and the result of it came later than the one of the second request.