### PR TITLE
fix: Tracking status not always shown for same version

### DIFF
--- a/client/src/lib/Advisories/RelatedDocuments.svelte
+++ b/client/src/lib/Advisories/RelatedDocuments.svelte
@@ -124,11 +124,22 @@
     push("/diff");
   };
 
+  // Get document as an object that can be compared with the other documents.
+  const getComparableDocument = () => {
+    return {
+      publisher: document.publisher.name,
+      tracking_id: document.tracking.id,
+      tracking_version: document.tracking.version,
+      tracking_status: document.tracking.status
+    };
+  };
+
   // Find out if there is a document of the same advisory with same version number but different tracking status because we show
   // tracking status only if there are at least two documents with same version number.
   const hasDocWithSameVersion = (doc: any) => {
+    const docs = [...Object.values(documents), getComparableDocument()];
     return (
-      Object.values(documents).find(
+      docs.find(
         (d: any) =>
           d.publisher === doc.publisher &&
           d.tracking_id === doc.tracking_id &&
@@ -188,8 +199,8 @@
               advisoryState,
               document?.tracking.version,
               ssvc,
-              undefined,
-              false
+              document?.tracking.status,
+              hasDocWithSameVersion(getComparableDocument())
             )}
           </div>
         </TableHeadCell>


### PR DESCRIPTION
When the doc where the users comes from had the same version as a related doc the tracking status wasn't displayed although it should to be consistent:
<img width="993" height="215" alt="Screenshot from 2026-04-29 08-54-30" src="https://github.com/user-attachments/assets/63254cdb-65eb-464a-83ca-d68e8dcb5d36" />

With this PR:
<img width="993" height="215" alt="Screenshot from 2026-04-29 08-57-12" src="https://github.com/user-attachments/assets/f757aa2e-60e7-421f-9aeb-c865989a2901" />
