### PR TITLE
Improve workflow state buttons

### DIFF
--- a/client/src/lib/Advisories/WorkflowButton.svelte
+++ b/client/src/lib/Advisories/WorkflowButton.svelte
@@ -9,25 +9,56 @@
 -->
 <script lang="ts">
   import CBadge from "$lib/Components/CBadge.svelte";
-  import type { Snippet } from "svelte";
+  import { getAllowedWorkflowChanges } from "$lib/permissions";
+  import { getContext, type Snippet } from "svelte";
 
   interface Props {
-    color: any;
-    label: string;
+    state: string;
     tooltip: string;
     icon: Snippet;
-    onClick: (event: any) => void;
+    onClick?: (event: any) => void;
   }
-  let { color, label, tooltip, icon, onClick }: Props = $props();
+  let { state, tooltip, icon, onClick = undefined }: Props = $props();
 
-  const buttonClass = $derived.by(() => {
-    return `h-fit w-fit rounded-xs border-0 p-0 hover:bg-transparent ${color !== "none" && color !== "green" ? "cursor-pointer" : ""}`;
+  let currentState: () => string = getContext("currentState");
+  let updateStateFn: () => (newState: string) => void = getContext("updateStateFn");
+
+  let allowedTargetStates = $derived(
+    getAllowedWorkflowChanges([currentState()]).map((transition) => transition.to)
+  );
+
+  let disabled = $derived.by(() => {
+    return currentState() === undefined || !allowedTargetStates.includes(state);
   });
+
+  let badgeColor: any = $derived.by(() => {
+    if (state === currentState()) {
+      return "green";
+    } else if (!disabled) {
+      return "dark";
+    } else {
+      return "none";
+    }
+  });
+
+  const buttonClass =
+    "h-fit w-fit rounded-xs border-0 p-0 hover:bg-transparent cursor-pointer disabled:cursor-default";
 </script>
 
-<button class={buttonClass} onclick={(event: any) => onClick(event)}>
-  <CBadge showHoverEffect={false} title={tooltip} class="flex w-fit gap-1" {color}>
+<button
+  {disabled}
+  class={buttonClass}
+  onclick={(event: any) => {
+    if (onClick) {
+      onClick(event);
+    } else if (updateStateFn) {
+      const callback = updateStateFn();
+      callback(state);
+    }
+  }}
+>
+  <CBadge showHoverEffect={false} title={tooltip} class="flex w-fit gap-1" color={badgeColor}>
     {@render icon()}
-    <span>{label}</span>
+    <span>{state}</span>
   </CBadge>
 </button>

--- a/client/src/lib/Advisories/WorkflowStates.svelte
+++ b/client/src/lib/Advisories/WorkflowStates.svelte
@@ -9,9 +9,10 @@
 -->
 <script lang="ts">
   import { ASSESSING, ARCHIVED, DELETE, NEW, READ, REVIEW, EDITOR, REVIEWER } from "$lib/workflow";
-  import { allowedToChangeWorkflow, isRoleIncluded } from "$lib/permissions";
+  import { isRoleIncluded } from "$lib/permissions";
   import { appStore } from "$lib/store.svelte";
   import WorkflowButton from "./WorkflowButton.svelte";
+  import { setContext } from "svelte";
 
   interface Props {
     advisoryState: string;
@@ -19,112 +20,65 @@
   }
   let { advisoryState = "", updateStateFn }: Props = $props();
 
-  const updateStateIfAllowed = async (state: string) => {
-    if (allowedToChangeWorkflow(appStore.getRoles(), advisoryState, state)) {
-      await updateStateFn(state);
-    }
-  };
-
-  const getBadgeColor = (state: string, currentState: string) => {
-    if (state === currentState) {
-      return "green";
-    } else if (allowedToChangeWorkflow(appStore.getRoles(), currentState, state)) {
-      return "dark";
-    } else {
-      return "none";
-    }
-  };
+  setContext("currentState", () => advisoryState);
+  setContext("updateStateFn", () => updateStateFn);
 </script>
 
-{#if advisoryState}
+<WorkflowButton state={NEW} tooltip="Mark as read">
+  {#snippet icon()}
+    <i class="bx bxs-certification"></i>
+  {/snippet}
+</WorkflowButton>
+<WorkflowButton state={READ} tooltip="Mark as read">
+  {#snippet icon()}
+    <i class="bx bx-show"></i>
+  {/snippet}
+</WorkflowButton>
+{#if (isRoleIncluded( appStore.getRoles(), [EDITOR, REVIEWER] ) && advisoryState === REVIEW) || (isRoleIncluded( appStore.getRoles(), [EDITOR] ) && advisoryState === ARCHIVED)}
   <WorkflowButton
-    onClick={() => updateStateIfAllowed(NEW)}
-    color={getBadgeColor(NEW, advisoryState)}
-    label={NEW}
-    tooltip="Mark as read"
+    onClick={() => {
+      document.getElementById("comment-textarea")?.focus();
+    }}
+    state={ASSESSING}
+    tooltip="Mark as assesing"
   >
     {#snippet icon()}
-      <i class="bx bxs-certification"></i>
+      <i class="bx bxs-analyse"></i>
     {/snippet}
   </WorkflowButton>
-  <WorkflowButton
-    onClick={() => updateStateIfAllowed(READ)}
-    color={getBadgeColor(READ, advisoryState)}
-    label={READ}
-    tooltip="Mark as read"
-  >
+{:else}
+  <WorkflowButton state={ASSESSING} tooltip="Mark as assesing">
     {#snippet icon()}
-      <i class="bx bx-show"></i>
-    {/snippet}
-  </WorkflowButton>
-  {#if (isRoleIncluded( appStore.getRoles(), [EDITOR, REVIEWER] ) && advisoryState === REVIEW) || (isRoleIncluded( appStore.getRoles(), [EDITOR] ) && advisoryState === ARCHIVED)}
-    <WorkflowButton
-      onClick={() => {
-        document.getElementById("comment-textarea")?.focus();
-      }}
-      color="dark"
-      label={ASSESSING}
-      tooltip="Mark as assesing"
-    >
-      {#snippet icon()}
-        <i class="bx bxs-analyse"></i>
-      {/snippet}
-    </WorkflowButton>
-  {:else}
-    <WorkflowButton
-      onClick={() => updateStateIfAllowed(ASSESSING)}
-      color={getBadgeColor(ASSESSING, advisoryState)}
-      label={ASSESSING}
-      tooltip="Mark as assesing"
-    >
-      {#snippet icon()}
-        <i class="bx bxs-analyse"></i>
-      {/snippet}
-    </WorkflowButton>
-  {/if}
-  {#if advisoryState === ARCHIVED && isRoleIncluded(appStore.getRoles(), [EDITOR])}
-    <WorkflowButton
-      onClick={() => {
-        document.getElementById("comment-textarea")?.focus();
-      }}
-      color="dark"
-      label={REVIEW}
-      tooltip="Release for review"
-    >
-      {#snippet icon()}
-        <i class="bx bx-book-open"></i>
-      {/snippet}
-    </WorkflowButton>
-  {:else}
-    <WorkflowButton
-      onClick={() => updateStateIfAllowed(REVIEW)}
-      color={getBadgeColor(REVIEW, advisoryState)}
-      label={REVIEW}
-      tooltip="Release for review"
-    >
-      {#snippet icon()}
-        <i class="bx bx-book-open"></i>
-      {/snippet}
-    </WorkflowButton>
-  {/if}
-  <WorkflowButton
-    onClick={() => updateStateIfAllowed(ARCHIVED)}
-    color={getBadgeColor(ARCHIVED, advisoryState)}
-    label={ARCHIVED}
-    tooltip="Archive"
-  >
-    {#snippet icon()}
-      <i class="bx bx-archive"></i>
-    {/snippet}
-  </WorkflowButton>
-  <WorkflowButton
-    onClick={() => updateStateFn(DELETE)}
-    color={getBadgeColor(DELETE, advisoryState)}
-    label={DELETE}
-    tooltip="Mark for deletion"
-  >
-    {#snippet icon()}
-      <i class="bx bx-trash"></i>
+      <i class="bx bxs-analyse"></i>
     {/snippet}
   </WorkflowButton>
 {/if}
+{#if advisoryState === ARCHIVED && isRoleIncluded(appStore.getRoles(), [EDITOR])}
+  <WorkflowButton
+    onClick={() => {
+      document.getElementById("comment-textarea")?.focus();
+    }}
+    state={REVIEW}
+    tooltip="Release for review"
+  >
+    {#snippet icon()}
+      <i class="bx bx-book-open"></i>
+    {/snippet}
+  </WorkflowButton>
+{:else}
+  <WorkflowButton state={REVIEW} tooltip="Release for review">
+    {#snippet icon()}
+      <i class="bx bx-book-open"></i>
+    {/snippet}
+  </WorkflowButton>
+{/if}
+<WorkflowButton state={ARCHIVED} tooltip="Archive">
+  {#snippet icon()}
+    <i class="bx bx-archive"></i>
+  {/snippet}
+</WorkflowButton>
+<WorkflowButton state={DELETE} tooltip="Mark for deletion">
+  {#snippet icon()}
+    <i class="bx bx-trash"></i>
+  {/snippet}
+</WorkflowButton>


### PR DESCRIPTION
Improve maintainability:

- less props have to be passed
- variables and methods are less complicated (e.g. `buttonClass` is now a simple string)

Improve UI when advisory view is loaded:

The workflow state buttons are now visible right away but they are disabled until the advisory state is known. This way at least this part of the UI is less "noisy".