### PR TITLE
fix: Match list style in Search

### DIFF
--- a/client/src/lib/Table/MatchList.svelte
+++ b/client/src/lib/Table/MatchList.svelte
@@ -16,14 +16,13 @@
   import { splitMatches } from "$lib/utils";
 
   interface Props {
-    colspan: number;
     doc: any;
     externalIndex: number;
     matches?: any[];
     index: number;
   }
 
-  let { colspan, doc, externalIndex, matches = [], index }: Props = $props();
+  let { doc, externalIndex, matches = [], index }: Props = $props();
   let uid = $props.id();
 
   let expanded = $state(false);
@@ -60,7 +59,7 @@
   {#if match[searchColumnName]}
     {@const splits = getSplits(match[searchColumnName])}
     <tr class={getTableRowClass(i)}>
-      <TableBodyCell {colspan} class="px-0 py-0 whitespace-nowrap">
+      <TableBodyCell colspan={100} class="px-0 py-0 whitespace-nowrap">
         <Link
           ariaLabel={`Navigate directly to the ${i + 1}. match`}
           class={index % 2 == 1 ? "block" : "block"}

--- a/client/src/lib/Table/Table.svelte
+++ b/client/src/lib/Table/Table.svelte
@@ -681,13 +681,7 @@
             </tr>
             {#if [SEARCHTYPES.ADVISORY, SEARCHTYPES.DOCUMENT].includes(tableType)}
               {#if doc.data}
-                <MatchList
-                  colspan={columns.length}
-                  doc={item}
-                  externalIndex={i}
-                  matches={doc.data}
-                  index={i}
-                />
+                <MatchList doc={item} externalIndex={i} matches={doc.data} index={i} />
               {/if}
             {/if}
           {/each}


### PR DESCRIPTION
The rows of the matches below the documents did not reach to the end so you had a gap at the right side:

<img width="1878" height="231" alt="match-list" src="https://github.com/user-attachments/assets/bf04d95b-36f4-4221-892c-72bdee750e5d" />
