### PR TITLE
Make link to search doc version-specific

### DIFF
--- a/client/src/lib/Queries/QueryDesigner.svelte
+++ b/client/src/lib/Queries/QueryDesigner.svelte
@@ -35,7 +35,7 @@
   import { isRoleIncluded } from "$lib/permissions";
   import Sortable from "sortablejs";
   import TypeToggle from "$lib/Search/TypeToggle.svelte";
-  import Link from "$lib/Components/Link.svelte";
+  import SearchDocLink from "$lib/Search/SearchDocLink.svelte";
 
   interface Props {
     params?: any;
@@ -481,13 +481,7 @@
     <div class="mt-6 w-full">
       <Label for="query-criteria">Query criteria:</Label>
       <Input disabled={!isAllowedToEdit} id="query-criteria" bind:value={currentSearch.query} />
-      <Link
-        href="https://github.com/ISDuBA/ISDuBA/blob/main/docs/search.md#filter-expressions"
-        class="text-sm underline"
-      >
-        <i class="bx bx-link"></i>
-        <span>Documentation: Filter expression</span>
-      </Link>
+      <SearchDocLink />
       {#if saveErrorMessage}
         <div class="mt-2 flex md:justify-end">
           <ErrorMessage error={saveErrorMessage}></ErrorMessage>

--- a/client/src/lib/Search/Overview.svelte
+++ b/client/src/lib/Search/Overview.svelte
@@ -28,8 +28,8 @@
   import { defaultQuery as defaultQ, queryState } from "./search.svelte";
   import { page } from "$app/state";
   import { untrack } from "svelte";
-  import Link from "$lib/Components/Link.svelte";
   import { slide } from "svelte/transition";
+  import SearchDocLink from "./SearchDocLink.svelte";
 
   const INITIAL_LIMIT = 10;
   const INITIAL_ORDER = ["-critical"];
@@ -454,13 +454,7 @@
   </div>
   {#if advanced}
     <div transition:slide>
-      <Link
-        href="https://github.com/ISDuBA/ISDuBA/blob/main/docs/search.md#filter-expressions"
-        class="text-sm underline"
-      >
-        <i class="bx bx-link"></i>
-        <span>Documentation: Filter expression</span>
-      </Link>
+      <SearchDocLink />
     </div>
   {/if}
 </div>

--- a/client/src/lib/Search/SearchDocLink.svelte
+++ b/client/src/lib/Search/SearchDocLink.svelte
@@ -1,0 +1,39 @@
+<!--
+ This file is Free Software under the Apache-2.0 License
+ without warranty, see README.md and LICENSES/Apache-2.0.txt for details.
+
+ SPDX-License-Identifier: Apache-2.0
+
+ SPDX-FileCopyrightText: 2026 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+ Software-Engineering: 2026 Intevation GmbH <https://intevation.de>
+-->
+
+<script lang="ts">
+  import Link from "$lib/Components/Link.svelte";
+  import { request } from "$lib/request";
+  import { onMount } from "svelte";
+
+  let version: string | undefined = $state(undefined);
+
+  let docLink = $derived.by(() => {
+    const commitHash = version?.split("-g")?.[1];
+    return `https://github.com/ISDuBA/ISDuBA/blob/${commitHash ?? "main"}/docs/search.md#filter-expressions`;
+  });
+
+  async function getVersion() {
+    const response = await request("api/about", "GET");
+    if (response.ok) {
+      const backendInfo = response.content;
+      version = backendInfo.version;
+    }
+  }
+
+  onMount(() => {
+    getVersion();
+  });
+</script>
+
+<Link href={docLink} class="text-sm underline">
+  <i class="bx bx-link"></i>
+  <span>Documentation: Filter expression</span>
+</Link>

--- a/client/tests/queries_test.ts
+++ b/client/tests/queries_test.ts
@@ -8,12 +8,17 @@
 
 import { expect } from "@playwright/test";
 import { test } from "./fixtures";
+import { docLinkRegex } from "./utils";
 
 const queryName = `Query ${Math.random()}`;
 
 test("Queries can be configured", async ({ page }) => {
   await page.goto("/#/queries");
   await page.getByRole("link", { name: "New query", exact: false }).first().click();
+
+  const docLinkHref = await page.getByRole("link", { name: "Documentation" }).getAttribute("href");
+  expect(docLinkHref).toBeDefined();
+  if (docLinkHref) expect(docLinkRegex.test(docLinkHref)).toBeTruthy();
   await page.getByLabel("Name:").fill(queryName);
   await page.getByLabel("Dashboard").check();
   await page.getByLabel("Hide").check();

--- a/client/tests/search_test.ts
+++ b/client/tests/search_test.ts
@@ -1,0 +1,20 @@
+// This file is Free Software under the Apache-2.0 License
+// without warranty, see README.md and LICENSES/Apache-2.0.txt for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: 2026 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+// Software-Engineering: 2026 Intevation GmbH <https://intevation.de>
+
+import { expect } from "@playwright/test";
+import { test } from "./fixtures";
+import { docLinkRegex } from "./utils";
+
+test("Advisory view is working", async ({ page }) => {
+  await page.goto("/#/search");
+  // Doesn't work without "force"
+  await page.getByLabel("Advanced").check({ force: true });
+  const docLinkHref = await page.getByRole("link", { name: "Documentation" }).getAttribute("href");
+  expect(docLinkHref).toBeDefined();
+  if (docLinkHref) expect(docLinkRegex.test(docLinkHref)).toBeTruthy();
+});

--- a/client/tests/utils.ts
+++ b/client/tests/utils.ts
@@ -1,0 +1,12 @@
+// This file is Free Software under the Apache-2.0 License
+// without warranty, see README.md and LICENSES/Apache-2.0.txt for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: 2026 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+// Software-Engineering: 2026 Intevation GmbH <https://intevation.de>
+
+const docLinkRegex =
+  /https:\/\/github\.com\/ISDuBA\/ISDuBA\/blob\/[\w\d]+\/docs\/search\.md#filter-expressions/;
+
+export { docLinkRegex };


### PR DESCRIPTION
Before the link to the search documentation always led to the latest documentation but if the user has an older client the documentation might not fit to the software. With this PR we link the documentation that fits to the specific commit which was used to build the client.

This PR implements the suggestion mention in this [comment](https://github.com/ISDuBA/ISDuBA/issues/1152#issuecomment-4460577289).