### PR TITLE
ci: improve go coverage collection and reporting

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -33,7 +33,7 @@ jobs:
           killall "-2" --wait isdubad
       - name: collect coverage of go code
         run: |
-          echo Working on the following cov files:
+          # Working on the following cov files:
           ls -l /tmp/cov
           go tool covdata textfmt -i=/tmp/cov -o coverage.out
           go tool cover -func=coverage.out
@@ -50,3 +50,7 @@ jobs:
           name: playwright-output
           path: client/playwright/output/ ## Folder used in playwright.config.js `outputDir`
           retention-days: 30
+      - uses: actions/upload-artifact@v7
+        with:
+          name: go-coverage.out
+          path: coverage.out

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -6,7 +6,7 @@
 # SPDX-FileCopyrightText: 2023 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
 # Software-Engineering: 2023 Intevation GmbH <https://intevation.de>
 
-name: Playwright Tests
+name: Playwright Tests and Coverage
 on:
   workflow_dispatch:
 jobs:
@@ -31,6 +31,10 @@ jobs:
           npm run cover
           cd ../
           killall "-2" --wait isdubad
+      - name: collect coverage of go code
+        run: |
+          echo Working on the following cov files:
+          ls -l /tmp/cov
           go tool covdata textfmt -i=/tmp/cov -o coverage.out
           go tool cover -func=coverage.out
         shell: bash

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -37,7 +37,8 @@ jobs:
         run: |
           # Working on the following cov files:
           ls -l /tmp/cov
-          cdir=go-coverage-${{ github.event.repository.updated_at}}
+          echo "DATETIME=$(date '+%Y%m%d-%H%M%S')" >> "$GITHUB_ENV"
+          cdir=go-coverage-$DATETIME
           mkdir -p go-coverage/$cdir
           cd go-coverage/$cdir
           # need old style textfmt to be able to calculate total percentage
@@ -58,5 +59,5 @@ jobs:
           retention-days: 30
       - uses: actions/upload-artifact@v7
         with:
-          name: go-coverage
+          name: go-coverage-${{ env.DATETIME }}
           path: go-coverage

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -38,7 +38,7 @@ jobs:
           # Working on the following cov files:
           ls -l /tmp/cov
           cdir=go-coverage-${{ github.event.repository.updated_at}}
-          mkdir go-coverage/$cdir
+          mkdir -p go-coverage/$cdir
           cd go-coverage/$cdir
           # need old style textfmt to be able to calculate total percentage
           go tool covdata textfmt -i=/tmp/cov -o coverage.out

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -16,7 +16,6 @@ jobs:
     env:
       BUILD_COVER: "true"
       GOCOVERDIR: "/tmp/cov"
-      CDIR: go-coverage-${{ github.event.repository.updated_at}}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -39,8 +38,8 @@ jobs:
           # Working on the following cov files:
           ls -l /tmp/cov
           cdir=go-coverage-${{ github.event.repository.updated_at}}
-          mkdir $cdir
-          cd $cdir
+          mkdir go-coverage/$cdir
+          cd go-coverage/$cdir
           # need old style textfmt to be able to calculate total percentage
           go tool covdata textfmt -i=/tmp/cov -o coverage.out
           go tool cover -func=coverage.out | tee cover_report.txt
@@ -59,5 +58,5 @@ jobs:
           retention-days: 30
       - uses: actions/upload-artifact@v7
         with:
-          name: go-coverage
-          path: ${{ env.CDIR }}
+          name: go-coverage-${{ github.event.repository.updated_at}}
+          path: go-coverage

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           node-version: lts/*
       - name: test installation scripts and playwright tests
+        shell: bash
         run: |
           mkdir /tmp/cov
           cd docs/scripts
@@ -32,12 +33,16 @@ jobs:
           cd ../
           killall "-2" --wait isdubad
       - name: collect coverage of go code
+        shell: bash
         run: |
           # Working on the following cov files:
           ls -l /tmp/cov
+          cdir=go-coverage-${{ github.event.repository.updated_at}}
+          mkdir $cdir
+          cd $cdir
+          # need old style textfmt to be able to calculate total percentage
           go tool covdata textfmt -i=/tmp/cov -o coverage.out
-          go tool cover -func=coverage.out
-        shell: bash
+          go tool cover -func=coverage.out | tee cover_report.txt
       - uses: actions/upload-artifact@v7
         if: always()
         with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -58,5 +58,5 @@ jobs:
           retention-days: 30
       - uses: actions/upload-artifact@v7
         with:
-          name: go-coverage-${{ github.event.repository.updated_at}}
+          name: go-coverage
           path: go-coverage

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -16,6 +16,7 @@ jobs:
     env:
       BUILD_COVER: "true"
       GOCOVERDIR: "/tmp/cov"
+      CDIR: go-coverage-${{ github.event.repository.updated_at}}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -58,5 +59,5 @@ jobs:
           retention-days: 30
       - uses: actions/upload-artifact@v7
         with:
-          name: go-coverage.out
-          path: coverage.out
+          name: go-coverage
+          path: ${{ env.CDIR }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -38,7 +38,7 @@ jobs:
           # Working on the following cov files:
           ls -l /tmp/cov
           echo "DATETIME=$(date '+%Y%m%d-%H%M%S')" >> "$GITHUB_ENV"
-          cdir=go-coverage-$DATETIME
+          cdir=go-coverage-${{ env.DATETIME }}
           mkdir -p go-coverage/$cdir
           cd go-coverage/$cdir
           # need old style textfmt to be able to calculate total percentage

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -43,6 +43,7 @@ jobs:
           # need old style textfmt to be able to calculate total percentage
           go tool covdata textfmt -i=/tmp/cov -o coverage.out
           go tool cover -func=coverage.out | tee cover_report.txt
+          cd ../
       - uses: actions/upload-artifact@v7
         if: always()
         with:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-#  This file is Free Software under the Apache-2.0 License
+# This file is Free Software under the Apache-2.0 License
 # without warranty, see README.md and LICENSES/Apache-2.0.txt for details.
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,17 @@ GO_FLAGS=$(LDFLAGS)
 
 # Build for coverage profile generation
 ifeq ($(BUILD_COVER), true)
-GO_FLAGS += "-cover"
+GO_FLAGS += -cover
+
+# needed to use the new format for go test -cover output
+# see https://github.com/golang/go/issues/51430#issuecomment-1344711300
+# from 2022-12-09
+#  > At the moment -test.gocoverdir is an unexported test flag,
+# tested with go1.26.3.
+# can be removed when https://go-review.googlesource.com/c/go/+/456595
+# or similar is solved.
+# (thanks https://dustinspecker.com/posts/go-combined-unit-integration-code-coverage/)
+GO_TEST_ARGS = -args "-test.gocoverdir=$(GOCOVERDIR)"
 endif
 
 
@@ -44,7 +54,7 @@ build_client:
 	cd client && npm clean-install && npm run build
 
 test:
-	go test ./...
+	go test $(GO_FLAGS) ./... $(GO_TEST_ARGS)
 
 DISTNAME := isduba-$(SEMVER)
 DISTDIR := dist/$(DISTNAME)


### PR DESCRIPTION
* Improve the workflow to upload a text report and the go coverage file in the old format.
* Improve Makefile to capture `go test`'s coverage information.