### PR TITLE
tests: add more time for long playwright test

### DIFF
--- a/client/tests/documentView_test.ts
+++ b/client/tests/documentView_test.ts
@@ -21,6 +21,7 @@ test.beforeEach(async ({ page }) => {
 });
 
 test("Advisory view is working", async ({ page }) => {
+  test.slow(); // Easy way to triple the default timeout
   await page.getByText("Avendor-advisory-0004", { exact: true }).first().click({ force: true });
   await expect(page.getByText("5.7 (MEDIUM)")).toBeVisible();
   await expect(page.getByText("Test CSAF document")).toBeVisible();


### PR DESCRIPTION
Avoid failure because of the variation of how long a test takes to run.