### PR TITLE
Resolve issues with URL-manipulation in CVE comparison table

### DIFF
--- a/client/src/lib/Advisories/Advisory.svelte
+++ b/client/src/lib/Advisories/Advisory.svelte
@@ -31,7 +31,8 @@
     fetchDocumentSSVC,
     fetchSearchHits,
     loadAdvisoryVersions,
-    advisorySearchState
+    advisorySearchState,
+    isResultConsistent
   } from "$lib/Advisories/advisory.svelte";
   import InconsistencyMessage from "$lib/Advisories/InconsistencyMessage.svelte";
   import SearchMatchBar from "./SearchMatchBar.svelte";
@@ -154,12 +155,7 @@
     );
     if (response.ok) {
       const result = await response.content;
-      if (
-        params.trackingID &&
-        params.publisherNamespace &&
-        (result.document.tracking.id !== params.trackingID ||
-          result.document.publisher.name !== params.publisherNamespace)
-      ) {
+      if (!isResultConsistent(params, result.document)) {
         isInconsistent = true;
       }
       ({ document } = result);

--- a/client/src/lib/Advisories/InconsistencyMessage.svelte
+++ b/client/src/lib/Advisories/InconsistencyMessage.svelte
@@ -18,14 +18,17 @@
   interface Props {
     params: any;
     document: any;
+    relatedDocuments?: boolean; // Show messages and URLs for related documents
   }
 
-  let { params = null, document = {} }: Props = $props();
+  let { params = null, document = {}, relatedDocuments = false }: Props = $props();
 
   const uid = $props.id();
 
   let loadAdvisoryVersionsError: ErrorDetails | null = $state(null);
   let advisoryVersions: AdvisoryVersion[] = $state([]);
+
+  let urlSuffix = $derived(relatedDocuments ? "/related/documents" : "");
 
   let suggestedPublisherNamespace = $derived(document.publisher.name);
   let suggestedTrackingID = $derived(document.tracking.id);
@@ -38,10 +41,10 @@
       : undefined
   );
   let suggestedLinkByID = $derived(
-    `/advisories/${suggestedPublisherNamespace}/${suggestedTrackingID}/documents/${params.id}`
+    `/advisories/${suggestedPublisherNamespace}/${suggestedTrackingID}/documents/${params.id}${urlSuffix}`
   );
   let encodedSuggestedLinkByID = $derived(
-    `/advisories/${encodedPublisherNamespace}/${encodedTrackingID}/documents/${params.id}`
+    `/advisories/${encodedPublisherNamespace}/${encodedTrackingID}/documents/${params.id}${urlSuffix}`
   );
 
   const getAdvisoryVersions = async () => {
@@ -70,7 +73,11 @@
     <span>The URL doesn't reference any document</span>
   </div>
   <P>
-    Do you want to open the document with ID {params.id}?
+    {#if relatedDocuments}
+      Do you want to open the related documents of the document with ID {params.id}?
+    {:else}
+      Do you want to open the document with ID {params.id}?
+    {/if}
     <br />
     <A href={`#${encodedSuggestedLinkByID}`}>{suggestedLinkByID}</A>
   </P>

--- a/client/src/lib/Advisories/RelatedDocuments.svelte
+++ b/client/src/lib/Advisories/RelatedDocuments.svelte
@@ -182,72 +182,81 @@
       Loading ...
       <Spinner color="gray" size="4"></Spinner>
     </div>
-  {:else if documents && cves}
-    <CustomTable
-      tableClass="h-fit w-fit border-separate border-spacing-0"
-      tableContainerClass="h-full"
-      containerClass="h-full"
-      hoverable={false}
-      title={`Documents having the same CVEs as ${params.trackingID ?? document?.tracking?.id}`}
-      stickyHeaders={true}
-    >
-      {#snippet tableHeadSlot()}
-        <TableHeadCell class="text-center align-top">
-          <div class="flex flex-col items-center gap-2">
-            <span>{params.trackingID ?? document?.tracking?.id}</span>
-            {@render generalInformation(
-              advisoryState,
-              document?.tracking.version,
-              ssvc,
-              document?.tracking.status,
-              hasDocWithSameVersion(getComparableDocument())
-            )}
-          </div>
-        </TableHeadCell>
-        {#each Object.values(documents) as doc, i (`relateddocuments-1-${uid}-${i}`)}
-          {@const d = doc as any}
-          {@const sameVersion = hasDocWithSameVersion(d)}
+  {:else if document && documents && cves}
+    {#if Object.keys(cves).length === 0}
+      <div class="mb-2 font-bold">
+        <i class="bx bx-error-circle" aria-hidden="true"></i>
+        <span>The document {document?.tracking?.id} has no related documents.</span>
+      </div>
+    {:else}
+      <CustomTable
+        tableClass="h-fit w-fit border-separate border-spacing-0"
+        tableContainerClass="h-full"
+        containerClass="h-full"
+        hoverable={false}
+        title={`Documents having the same CVEs as ${params.trackingID ?? document?.tracking?.id}`}
+        stickyHeaders={true}
+      >
+        {#snippet tableHeadSlot()}
           <TableHeadCell class="text-center align-top">
-            <div class="flex h-full flex-col items-center justify-between gap-2">
-              <Link
-                class="text-primary-700 dark:text-primary-400 hover:underline"
-                href={`/#/advisories/${encodeURIComponent(d.publisher)}/${encodeURIComponent(d.tracking_id)}/documents/${d.document_id}`}
-                >{d.tracking_id}</Link
-              >
+            <div class="flex flex-col items-center gap-2">
+              <span>{params.trackingID ?? document?.tracking?.id}</span>
               {@render generalInformation(
-                d.state,
-                d.tracking_version,
-                d.ssvc,
-                d.tracking_status,
-                sameVersion
+                advisoryState,
+                document?.tracking.version,
+                ssvc,
+                document?.tracking.status,
+                hasDocWithSameVersion(getComparableDocument())
               )}
-              <Button color="light" size="xs" class="h-6" onclick={() => compare(d)}>
-                Compare
-              </Button>
             </div>
           </TableHeadCell>
-        {/each}
-      {/snippet}
-      {#snippet mainSlot()}
-        {#each Object.keys(cves as Related) as string[] as cve, j (`relateddocuments-1-${uid}-${j}`)}
-          <TableBodyRow
-            class={cve && cve === params.cve ? "!bg-primary-100 dark:!bg-primary-800" : ""}
-          >
-            <TableBodyCell class={`${baseClass} ${cve && cve === params.cve ? "!font-bold" : ""}`}>
-              {cve}
-            </TableBodyCell>
-            {#each Object.values(documents) as doc, k (`relateddocuments-1-${uid}-${k}`)}
-              <TableBodyCell class={baseClass}>
-                {#if (doc as any).cve.includes(cve)}
-                  <i
-                    class={`${baseClass} bx bx-check text-2xl ${cve && cve === params.cve ? "!font-bold" : ""}`}
-                  ></i>
-                {/if}
+          {#each Object.values(documents) as doc, i (`relateddocuments-1-${uid}-${i}`)}
+            {@const d = doc as any}
+            {@const sameVersion = hasDocWithSameVersion(d)}
+            <TableHeadCell class="text-center align-top">
+              <div class="flex h-full flex-col items-center justify-between gap-2">
+                <Link
+                  class="text-primary-700 dark:text-primary-400 hover:underline"
+                  href={`/#/advisories/${encodeURIComponent(d.publisher)}/${encodeURIComponent(d.tracking_id)}/documents/${d.document_id}`}
+                  >{d.tracking_id}</Link
+                >
+                {@render generalInformation(
+                  d.state,
+                  d.tracking_version,
+                  d.ssvc,
+                  d.tracking_status,
+                  sameVersion
+                )}
+                <Button color="light" size="xs" class="h-6" onclick={() => compare(d)}>
+                  Compare
+                </Button>
+              </div>
+            </TableHeadCell>
+          {/each}
+        {/snippet}
+        {#snippet mainSlot()}
+          {#each Object.keys(cves as Related) as string[] as cve, j (`relateddocuments-1-${uid}-${j}`)}
+            <TableBodyRow
+              class={cve && cve === params.cve ? "!bg-primary-100 dark:!bg-primary-800" : ""}
+            >
+              <TableBodyCell
+                class={`${baseClass} ${cve && cve === params.cve ? "!font-bold" : ""}`}
+              >
+                {cve}
               </TableBodyCell>
-            {/each}
-          </TableBodyRow>
-        {/each}
-      {/snippet}
-    </CustomTable>
+              {#each Object.values(documents) as doc, k (`relateddocuments-1-${uid}-${k}`)}
+                <TableBodyCell class={baseClass}>
+                  {#if (doc as any).cve.includes(cve)}
+                    <i
+                      class={`${baseClass} bx bx-check text-2xl ${cve && cve === params.cve ? "!font-bold" : ""}`}
+                    ></i>
+                  {/if}
+                </TableBodyCell>
+              {/each}
+            </TableBodyRow>
+          {/each}
+        {/snippet}
+      </CustomTable>
+    {/if}
   {/if}
 </div>

--- a/client/src/lib/Advisories/RelatedDocuments.svelte
+++ b/client/src/lib/Advisories/RelatedDocuments.svelte
@@ -14,14 +14,15 @@
   import { request } from "$lib/request";
   import CustomTable from "$lib/Table/CustomTable.svelte";
   import { Button, Spinner, TableBodyCell, TableBodyRow, TableHeadCell } from "flowbite-svelte";
-  import { onMount, tick } from "svelte";
+  import { tick } from "svelte";
   import WorkflowStateIcon from "$lib/Advisories/WorkflowStateIcon.svelte";
-  import { fetchDocumentSSVC } from "$lib/Advisories/advisory.svelte";
+  import { fetchDocumentSSVC, isResultConsistent } from "$lib/Advisories/advisory.svelte";
   import SSVCBadge from "./SSVC/SSVCBadge.svelte";
   import { push } from "$routes/router.svelte";
   import { appStore } from "$lib/store.svelte";
   import { addSlashes } from "$lib/utils";
   import Link from "$lib/Components/Link.svelte";
+  import InconsistencyMessage from "./InconsistencyMessage.svelte";
 
   interface Related {
     [key: string]: string[];
@@ -42,6 +43,7 @@
   let isLoading: boolean = $state(false);
   let advisoryState: string | undefined = $state(undefined);
   let loadError: ErrorDetails | null = $state(null);
+  let isInconsistent = $state(false);
 
   let encodedTrackingID = $derived(
     document?.tracking?.id ? encodeURIComponent(addSlashes(document.tracking?.id)) : undefined
@@ -67,54 +69,69 @@
   };
 
   const loadDocument = async () => {
+    isInconsistent = false;
     const response = await request(`/api/documents/${params.id}`, "GET");
     if (response.ok) {
       const result = await response.content;
       ({ document } = result);
+      if (!isResultConsistent(params, document)) {
+        isInconsistent = true;
+      }
     } else if (response.error) {
       loadError = getErrorDetails(`Could not load document.`, response);
     }
   };
 
-  onMount(async () => {
-    isLoading = true;
-    try {
-      await loadDocument();
-      if (loadError) return;
-      await tick();
-      if (!encodedTrackingID || !encodedPublisherNamespace) return;
-      const result = await fetchDocumentSSVC(params.id);
-      if (typeof result === "string") {
-        ssvc = result;
-      } else if (result?.message) {
-        loadError = result;
-        return;
-      }
-      loadAdvisoryState();
-      if (loadError) return;
-      const response = await request(`/api/documents/${params.id}/cve_related`, "GET");
-      if (response.ok) {
-        cves = {};
-        documents = {};
-        response.content.forEach((doc: any) => {
-          if (cves && !cves[doc.cve]) {
-            cves[doc.cve] = [doc];
-          } else if (cves) {
-            cves[doc.cve].push(doc);
+  $effect(() => {
+    if (params) {
+      setTimeout(async () => {
+        isLoading = true;
+        document = undefined;
+        documents = undefined;
+        cves = undefined;
+        loadError = null;
+        try {
+          await loadDocument();
+          if (loadError || isInconsistent) {
+            isLoading = false;
+            return;
           }
+          await tick();
+          if (!encodedTrackingID || !encodedPublisherNamespace) return;
+          const result = await fetchDocumentSSVC(params.id);
+          if (typeof result === "string") {
+            ssvc = result;
+          } else if (result?.message) {
+            loadError = result;
+            return;
+          }
+          loadAdvisoryState();
+          if (loadError) return;
+          const response = await request(`/api/documents/${params.id}/cve_related`, "GET");
+          if (response.ok) {
+            cves = {};
+            documents = {};
+            response.content.forEach((doc: any) => {
+              if (cves && !cves[doc.cve]) {
+                cves[doc.cve] = [doc];
+              } else if (cves) {
+                cves[doc.cve].push(doc);
+              }
 
-          if (!documents[doc.document_id]) {
-            documents[doc.document_id] = doc;
-            documents[doc.document_id].cve = [doc.cve];
-          } else if (documents) {
-            documents[doc.document_id].cve.push(doc.cve);
+              if (!documents[doc.document_id]) {
+                documents[doc.document_id] = doc;
+                documents[doc.document_id].cve = [doc.cve];
+              } else if (documents) {
+                documents[doc.document_id].cve.push(doc.cve);
+              }
+            });
+          } else if (response.error) {
+            loadError = getErrorDetails(`Could not load documents.`, response);
           }
-        });
-      } else if (response.error) {
-        loadError = getErrorDetails(`Could not load documents.`, response);
-      }
-    } finally {
-      isLoading = false;
+        } finally {
+          isLoading = false;
+        }
+      }, 0);
     }
   });
 
@@ -182,6 +199,8 @@
       Loading ...
       <Spinner color="gray" size="4"></Spinner>
     </div>
+  {:else if document && isInconsistent}
+    <InconsistencyMessage {document} {params} relatedDocuments />
   {:else if document && documents && cves}
     {#if Object.keys(cves).length === 0}
       <div class="mb-2 font-bold">

--- a/client/src/lib/Advisories/advisory.svelte.ts
+++ b/client/src/lib/Advisories/advisory.svelte.ts
@@ -177,6 +177,17 @@ const fetchSearchHits = async (id: number): Promise<SearchMatch[] | ErrorDetails
   return response.content;
 };
 
+// Check if the loaded document (which is loaded via the internal ID) complies
+// with the parameters in the URL.
+const isResultConsistent = (params: any, document: any) => {
+  return (
+    params.trackingID &&
+    params.publisherNamespace &&
+    document.tracking.id === params.trackingID &&
+    document.publisher.name === params.publisherNamespace
+  );
+};
+
 type AdvisorySearchState = {
   scroll: boolean;
   searchMatches: SearchMatch[];
@@ -210,6 +221,7 @@ export {
   fetchDocumentSSVC,
   fetchSearchHits,
   getAdvisoryAnchorLink,
-  getAdvisorySearchHit
+  getAdvisorySearchHit,
+  isResultConsistent
 };
 export type { AdvisoryVersion, SearchMatch };


### PR DESCRIPTION
Resolves #1272.

The solution is consistent to the one that we used when the URL for the advisory view was manipulated.