### PR TITLE
Fix invalid input error on pgx 5.10 version bump

### DIFF
--- a/pkg/sources/manager.go
+++ b/pkg/sources/manager.go
@@ -1112,7 +1112,7 @@ func (m *Manager) AddFeed(
 					sourceID,
 					url.String(),
 					rolie,
-					logLevel,
+					logLevel.String(),
 				).Scan(&feedID)
 			}, 0,
 		); err != nil {
@@ -1517,7 +1517,7 @@ func (fu *FeedUpdater) UpdateLogLevel(level config.FeedLogLevel) error {
 	if config.FeedLogLevel(fu.updatable.logLevel.Load()) == level {
 		return nil
 	}
-	fu.addChange(func(f *feed) { f.logLevel.Store(int32(level)) }, "log_lvl", level)
+	fu.addChange(func(f *feed) { f.logLevel.Store(int32(level)) }, "log_lvl", level.String())
 	return nil
 }
 


### PR DESCRIPTION
Fixes the error produced when adding a new feed or updating a feeds log level as described in #1541
by explicitly calling the String method of the FeedLogLevel type variables.

This fix will be necessary once the #1541 bump of pgx to version 5.10 is merged.