### PR TITLE
Improve related docs

### DIFF
--- a/client/src/lib/Advisories/RelatedDocuments.svelte
+++ b/client/src/lib/Advisories/RelatedDocuments.svelte
@@ -58,6 +58,7 @@
   let { params = null }: Props = $props();
 
   const uid = $props.id();
+  const STEP = 50;
 
   let document: any | undefined = $state(undefined);
   let documents: RelatedDocument[] | undefined = $state(undefined);
@@ -67,7 +68,7 @@
   let advisoryState: string | undefined = $state(undefined);
   let loadError: ErrorDetails | null = $state(null);
   let isInconsistent = $state(false);
-  let max = $state(50);
+  let max = $state(STEP);
 
   let encodedTrackingID = $derived(
     document?.tracking?.id ? encodeURIComponent(addSlashes(document.tracking?.id)) : undefined
@@ -298,17 +299,31 @@
             </TableHeadCell>
           {/each}
           {#if documents && max < documents.length}
-            <TableHeadCell class="">
-              <Button
-                onclick={() => {
-                  if (!documents) return;
-                  max = max + 50;
-                }}
-                class="h-6 text-nowrap"
-                color="light"
-              >
-                Load more...
-              </Button>
+            <TableHeadCell>
+              <div class="flex flex-col items-center gap-2">
+                <span class="text-gray-500 normal-case">Displaying {max} of {documents.length}</span
+                >
+                <Button
+                  onclick={() => {
+                    if (!documents) return;
+                    max = max + STEP;
+                  }}
+                  class="h-6 text-nowrap"
+                  color="light"
+                >
+                  Load {max + STEP >= documents.length ? documents.length - max : STEP} more...
+                </Button>
+                <Button
+                  onclick={() => {
+                    if (!documents) return;
+                    max = documents.length;
+                  }}
+                  class="h-6 text-nowrap"
+                  color="light"
+                >
+                  Load all...
+                </Button>
+              </div>
             </TableHeadCell>
           {/if}
         {/snippet}

--- a/client/src/lib/Advisories/RelatedDocuments.svelte
+++ b/client/src/lib/Advisories/RelatedDocuments.svelte
@@ -302,7 +302,7 @@
               <Button
                 onclick={() => {
                   if (!documents) return;
-                  max = Math.min(max + 50, documents?.length);
+                  max = max + 50;
                 }}
                 class="h-6 text-nowrap"
                 color="light"

--- a/client/src/lib/Advisories/RelatedDocuments.svelte
+++ b/client/src/lib/Advisories/RelatedDocuments.svelte
@@ -297,7 +297,7 @@
               </div>
             </TableHeadCell>
           {/each}
-          {#if documents && max <= documents.length}
+          {#if documents && max < documents.length}
             <TableHeadCell class="">
               <Button
                 onclick={() => {

--- a/client/src/lib/Advisories/RelatedDocuments.svelte
+++ b/client/src/lib/Advisories/RelatedDocuments.svelte
@@ -24,9 +24,31 @@
   import Link from "$lib/Components/Link.svelte";
   import InconsistencyMessage from "./InconsistencyMessage.svelte";
   import { AlertCircle, Check } from "@boxicons/svelte";
+  import type { WorkflowState } from "$lib/workflow";
 
-  interface Related {
-    [key: string]: string[];
+  interface BasicRelatedDocument {
+    document_id: number;
+    publisher: string;
+    ssvc?: string;
+    state: WorkflowState;
+    title: string;
+    tracking_id: string;
+    tracking_status: string;
+    tracking_version: string;
+  }
+
+  interface RelatedDocumentFromBackend extends BasicRelatedDocument {
+    cve: string;
+  }
+
+  interface RelatedDocument extends BasicRelatedDocument {
+    cve: string[];
+  }
+
+  interface RelatedCVEResponse {
+    error?: string;
+    ok: boolean;
+    content: RelatedDocumentFromBackend[];
   }
 
   interface Props {
@@ -38,8 +60,8 @@
   const uid = $props.id();
 
   let document: any | undefined = $state(undefined);
-  let documents: any | undefined = $state(undefined);
-  let cves: Related | undefined = $state(undefined);
+  let documents: RelatedDocument[] | undefined = $state(undefined);
+  let cves: string[] | undefined = $state(undefined);
   let ssvc: string | undefined = $state(undefined);
   let isLoading: boolean = $state(false);
   let advisoryState: string | undefined = $state(undefined);
@@ -108,24 +130,44 @@
           }
           loadAdvisoryState();
           if (loadError) return;
-          const response = await request(`/api/documents/${params.id}/cve_related`, "GET");
+          const response: RelatedCVEResponse = (await request(
+            `/api/documents/${params.id}/cve_related`,
+            "GET"
+          )) as RelatedCVEResponse;
           if (response.ok) {
-            cves = {};
-            documents = {};
-            response.content.forEach((doc: any) => {
-              if (cves && !cves[doc.cve]) {
-                cves[doc.cve] = [doc];
-              } else if (cves) {
-                cves[doc.cve].push(doc);
+            const newCves: string[] = [];
+            const newDocuments: RelatedDocument[] = [];
+
+            for (let i = 0; i < response.content.length; i++) {
+              const doc = response.content[i];
+              const docIndex = newDocuments.findIndex((d: RelatedDocument) => {
+                return doc.document_id === d.document_id;
+              });
+              if (docIndex === -1) {
+                newDocuments.push({
+                  ...doc,
+                  cve: [doc.cve]
+                });
+              } else {
+                newDocuments[docIndex].cve.push(doc.cve);
               }
 
-              if (!documents[doc.document_id]) {
-                documents[doc.document_id] = doc;
-                documents[doc.document_id].cve = [doc.cve];
-              } else if (documents) {
-                documents[doc.document_id].cve.push(doc.cve);
+              if (!newCves.includes(doc.cve)) {
+                newCves.push(doc.cve);
               }
+            }
+
+            // We are more interested in documents with more CVEs so they should come first
+            newDocuments.sort((a: RelatedDocument, b: RelatedDocument) => {
+              if (a.cve.length < b.cve.length) {
+                return -1;
+              } else if (a.cve.length > b.cve.length) {
+                return 1;
+              }
+              return 0;
             });
+            documents = newDocuments;
+            cves = newCves;
           } else if (response.error) {
             loadError = getErrorDetails(`Could not load documents.`, response);
           }
@@ -155,7 +197,8 @@
   // Find out if there is a document of the same advisory with same version number but different tracking status because we show
   // tracking status only if there are at least two documents with same version number.
   const hasDocWithSameVersion = (doc: any) => {
-    const docs = [...Object.values(documents), getComparableDocument()];
+    if (!documents) return false;
+    const docs = [...documents, getComparableDocument()];
     return (
       docs.find(
         (d: any) =>
@@ -203,7 +246,7 @@
   {:else if document && isInconsistent}
     <InconsistencyMessage {document} {params} relatedDocuments />
   {:else if document && documents && cves}
-    {#if Object.keys(cves).length === 0}
+    {#if documents?.length === 0}
       <div class="mb-2 font-bold">
         <AlertCircle aria-hidden="true" />
         <span>The document {document?.tracking?.id} has no related documents.</span>
@@ -230,8 +273,8 @@
               )}
             </div>
           </TableHeadCell>
-          {#each Object.values(documents) as doc, i (`relateddocuments-1-${uid}-${i}`)}
-            {@const d = doc as any}
+          {#each documents as doc, i (`relateddocuments-1-${uid}-${i}`)}
+            {@const d = doc as RelatedDocument}
             {@const sameVersion = hasDocWithSameVersion(d)}
             <TableHeadCell class="text-center align-top">
               <div class="flex h-full flex-col items-center justify-between gap-2">
@@ -255,7 +298,7 @@
           {/each}
         {/snippet}
         {#snippet mainSlot()}
-          {#each Object.keys(cves as Related) as string[] as cve, j (`relateddocuments-1-${uid}-${j}`)}
+          {#each cves as cve, j (`relateddocuments-1-${uid}-${j}`)}
             <TableBodyRow
               class={cve && cve === params.cve ? "!bg-primary-100 dark:!bg-primary-800" : ""}
             >
@@ -264,13 +307,13 @@
               >
                 {cve}
               </TableBodyCell>
-              {#each Object.values(documents) as doc, k (`relateddocuments-1-${uid}-${k}`)}
+              {#each documents as doc, k (`relateddocuments-1-${uid}-${k}`)}
                 <TableBodyCell class={baseClass}>
-                  {#if (doc as any).cve.includes(cve)}
-                    <Check
-                      class={`${baseClass} text-2xl ${cve && cve === params.cve ? "!font-bold" : ""}`}
-                    />
-                  {/if}
+                  <div class="flex justify-center">
+                    {#if (doc as RelatedDocument).cve.includes(cve)}
+                      <Check />
+                    {/if}
+                  </div>
                 </TableBodyCell>
               {/each}
             </TableBodyRow>

--- a/client/src/lib/Advisories/RelatedDocuments.svelte
+++ b/client/src/lib/Advisories/RelatedDocuments.svelte
@@ -67,6 +67,7 @@
   let advisoryState: string | undefined = $state(undefined);
   let loadError: ErrorDetails | null = $state(null);
   let isInconsistent = $state(false);
+  let max = $state(50);
 
   let encodedTrackingID = $derived(
     document?.tracking?.id ? encodeURIComponent(addSlashes(document.tracking?.id)) : undefined
@@ -273,7 +274,7 @@
               )}
             </div>
           </TableHeadCell>
-          {#each documents as doc, i (`relateddocuments-1-${uid}-${i}`)}
+          {#each documents?.slice(0, max) as doc, i (`relateddocuments-1-${uid}-${i}`)}
             {@const d = doc as RelatedDocument}
             {@const sameVersion = hasDocWithSameVersion(d)}
             <TableHeadCell class="text-center align-top">
@@ -296,6 +297,20 @@
               </div>
             </TableHeadCell>
           {/each}
+          {#if documents && max <= documents.length}
+            <TableHeadCell class="">
+              <Button
+                onclick={() => {
+                  if (!documents) return;
+                  max = Math.min(max + 50, documents?.length);
+                }}
+                class="h-6 text-nowrap"
+                color="light"
+              >
+                Load more...
+              </Button>
+            </TableHeadCell>
+          {/if}
         {/snippet}
         {#snippet mainSlot()}
           {#each cves as cve, j (`relateddocuments-1-${uid}-${j}`)}
@@ -307,7 +322,7 @@
               >
                 {cve}
               </TableBodyCell>
-              {#each documents as doc, k (`relateddocuments-1-${uid}-${k}`)}
+              {#each documents?.slice(0, max) as doc, k (`relateddocuments-1-${uid}-${k}`)}
                 <TableBodyCell class={baseClass}>
                   <div class="flex justify-center">
                     {#if (doc as RelatedDocument).cve.includes(cve)}


### PR DESCRIPTION
Resolves #1282 and resolves #1579.

When there are more than 50 related docs a button will be shown to load more at the right side of the table:
<img width="463" height="202" alt="Screenshot from 2026-08-31 16-12-30" src="https://github.com/user-attachments/assets/89352aff-16b7-4938-8441-9abf7cfa1d30" />

