### PR TITLE
fix: Background color in light theme

### DIFF
--- a/client/src/app.html
+++ b/client/src/app.html
@@ -18,10 +18,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     %sveltekit.head%
   </head>
-  <body
-    data-sveltekit-preload-data="hover"
-    class="bg-primary-700 flex h-screen dark:bg-gray-800 dark:text-white"
-  >
+  <body data-sveltekit-preload-data="hover" class="flex h-screen dark:bg-gray-800 dark:text-white">
     <div style="display: contents">%sveltekit.body%</div>
   </body>
 </html>


### PR DESCRIPTION
The PR #1583 led to the issue that the background color was blue at the top of the light theme:

<img width="1278" height="156" alt="Screenshot from 2026-08-31 20-10-46" src="https://github.com/user-attachments/assets/e1e82891-d833-48ad-9650-fe08593b0499" />

This PR solves this issue.